### PR TITLE
ci: Enable trusted publishing and npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,10 @@ on:
   workflow_dispatch:
 
 permissions:
+  # Enable reading repository contents (allows checkout without token)
   contents: read
-  id-token: write # Required for npm provenance
+  # Enable the use of OIDC for trusted publishing and npm provenance
+  id-token: write
 
 jobs:
   publish:
@@ -22,6 +24,9 @@ jobs:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
           scope: "@doist"
+
+      - name: Ensure npm 11.5.1 or later is installed
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -53,5 +58,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --tag ${{ steps.npm-tag.outputs.tag }} --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
             "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
@@ -2157,7 +2156,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.9",
                 "caniuse-lite": "^1.0.30001746",
@@ -2900,7 +2898,6 @@
             "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
             "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.0",
@@ -3632,7 +3629,6 @@
             "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "30.2.0",
                 "@jest/types": "30.2.0",
@@ -5901,7 +5897,6 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
             "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "license": "(MIT OR CC0-1.0)",
-            "peer": true,
             "engines": {
                 "node": ">=16"
             },
@@ -5929,7 +5924,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -6334,7 +6328,6 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }


### PR DESCRIPTION
## Overview

This PR updates the repository's GitHub Actions workflow to use **npm's Trusted Publishing** feature for package releases. Using Trusted Publishing eliminates the need to store long-lived npm tokens in GitHub secrets, reducing security risks and simplifying credential management. This also standardizes the publishing process across repositories.

> [!IMPORTANT]
> The npm organization and repository must be linked and authorized for Trusted Publishing before merging.

**What's changing:**

* Replaces manual `NPM_TOKEN` authentication with GitHub's **OpenID Connect (OIDC)**–based authentication.
* Updates the release workflow configuration to align with [npm's Trusted Publishers documentation](https://docs.npmjs.com/trusted-publishers)
* Ensures that package publishing permissions are managed directly through GitHub and npm, improving security and maintainability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)