### PR TITLE
chore(deps): Updates `@doist/twist-sdk` to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.2.0",
             "license": "MIT",
             "dependencies": {
-                "@doist/twist-sdk": "1.0.1",
+                "@doist/twist-sdk": "1.0.2",
                 "@modelcontextprotocol/sdk": "1.22.0",
                 "dotenv": "17.2.3",
                 "zod": "3.25.76"
@@ -719,13 +719,14 @@
             }
         },
         "node_modules/@doist/twist-sdk": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-1.0.1.tgz",
-            "integrity": "sha512-ZU2Cs64KegiMNAIk4EDnhdFLw45PfvoyoXZnzVH4YkJpTBlDNjueyFv/aJBbObDvUT9RCsc3C+x7+JSbFkwNWg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-1.0.2.tgz",
+            "integrity": "sha512-bHLxRJh8dx0W77PSGdK/Z/o05Jn2DH4/Oj9DTMDA92Gie+uf8/VbjT9dfOTAEl/McAwstUdbA1agkaiUr8GepA==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "8.0.0",
                 "ts-custom-error": "^3.2.0",
+                "undici": "^7.16.0",
                 "uuid": "^11.1.0",
                 "zod": "4.1.12"
             },
@@ -5952,6 +5953,15 @@
             "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/undici": {
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+            "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
+            }
         },
         "node_modules/undici-types": {
             "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "check:fix": "biome check --fix --unsafe"
     },
     "dependencies": {
-        "@doist/twist-sdk": "1.0.1",
+        "@doist/twist-sdk": "1.0.2",
         "@modelcontextprotocol/sdk": "1.22.0",
         "dotenv": "17.2.3",
         "zod": "3.25.76"


### PR DESCRIPTION
As per the title. 