### PR TITLE
feat!: upgrade to Zod v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@doist/twist-sdk": "1.0.2",
                 "@modelcontextprotocol/sdk": "1.24.0",
                 "dotenv": "17.2.3",
-                "zod": "3.25.76"
+                "zod": "4.1.13"
             },
             "bin": {
                 "twist-ai": "dist/main.js"
@@ -6326,9 +6326,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.25.76",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
+            "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@doist/twist-sdk": "1.0.2",
         "@modelcontextprotocol/sdk": "1.24.0",
         "dotenv": "17.2.3",
-        "zod": "3.25.76"
+        "zod": "4.1.13"
     },
     "devDependencies": {
         "@biomejs/biome": "2.3.7",

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -1,6 +1,6 @@
 import type { TwistApi } from '@doist/twist-sdk'
 import type { McpServer, ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
-import { type ZodTypeAny, z } from 'zod'
+import { z } from 'zod'
 import type { TwistTool } from './twist-tool.js'
 import { removeNullFields } from './utils/sanitize-data.js'
 import { getMcpAnnotations } from './utils/tool-mutability.js'
@@ -77,10 +77,7 @@ function registerTool<Params extends z.ZodRawShape, Output extends z.ZodRawShape
     client: TwistApi,
 ) {
     // @ts-expect-error I give up
-    const cb: ToolCallback<Params> = async (
-        args: z.objectOutputType<Params, ZodTypeAny>,
-        _context,
-    ) => {
+    const cb: ToolCallback<Params> = async (args: z.infer<z.ZodObject<Params>>, _context) => {
         try {
             const result = await tool.execute(args as z.infer<z.ZodObject<Params>>, client)
             return result


### PR DESCRIPTION
## Summary
Upgrades the project from Zod v3 to Zod v4.

## Changes
- Upgraded `zod` from v3.25.76 to v4.1.13
- Fixed `z.objectOutputType` → `z.infer<z.ZodObject<Params>>` in mcp-helpers.ts
- Removed unused `ZodTypeAny` import

## Breaking Changes
⚠️ **BREAKING CHANGE**: Output schema types are now more strict with Zod v4.

While this is primarily a type-level breaking change (runtime behavior is unchanged), TypeScript consumers may need to update their types.

## Verification
- ✅ All 88 tests pass (12 test suites)
- ✅ Type-check passes with zero errors
- ✅ Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)