### PR TITLE
fix: register build_link tool in MCP server

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,6 +1,7 @@
 import { TwistApi } from '@doist/twist-sdk'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { registerTool } from './mcp-helpers.js'
+import { buildLink } from './tools/build-link.js'
 import { fetchInbox } from './tools/fetch-inbox.js'
 import { getUsers } from './tools/get-users.js'
 import { getWorkspaces } from './tools/get-workspaces.js'
@@ -65,6 +66,7 @@ function getMcpServer({ twistApiKey, baseUrl }: { twistApiKey: string; baseUrl?:
     registerTool(loadThread, server, twist)
     registerTool(loadConversation, server, twist)
     registerTool(searchContent, server, twist)
+    registerTool(buildLink, server, twist)
     registerTool(reply, server, twist)
     registerTool(react, server, twist)
     registerTool(markDone, server, twist)


### PR DESCRIPTION
## Summary
- Fixes the `build_link` tool registration issue identified in #81
- Adds missing import and registration for the `build_link` tool in MCP server
- The tool was fully implemented with tests but was unusable due to missing registration

## Changes
- Added `import { buildLink } from './tools/build-link.js'` to `src/mcp-server.ts`
- Added `registerTool(buildLink, server, twist)` call to register the tool

## Test plan
- [x] Build passes successfully (`npm run build`)
- [x] TypeScript compilation successful
- [x] All existing functionality preserved
- [x] `build_link` tool is now properly registered and usable

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)