### PR TITLE
chore(deps): Restrict Node to v22

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
     "reviewersFromCodeOwners": true,
     "constraints": {
         "node": "^22.0.0"
-    }
+    },
     "packageRules": [
         {
             "matchPackageNames": ["*"],


### PR DESCRIPTION
If I understand [the docs](https://docs.renovatebot.com/language-constraints-and-upgrading/) correctly, this should prevent PRs like [this](https://github.com/Doist/twist-ai/pull/69).