### PR TITLE
feat: add automated cross-repository trigger for twist-ai-integrations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,3 +58,24 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --tag ${{ steps.npm-tag.outputs.tag }} --provenance --access public
+
+      - name: Get published version
+        id: get-version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "PACKAGE_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Trigger twist-ai-integrations update
+        if: success()
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/Doist/twist-ai-integrations/dispatches \
+            -f event_type='twist-ai-updated' \
+            -f client_payload='{"version":"${{ env.PACKAGE_VERSION }}","npm_tag":"${{ steps.npm-tag.outputs.tag }}"}'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true


### PR DESCRIPTION
## Summary

- Implements automated trigger of `update-twist-ai.yml` workflow in twist-ai-integrations repository when twist-ai is successfully published to npm
- Eliminates manual intervention while preserving existing manual trigger capability
- Uses organization `GITHUB_TOKEN` for cross-repo API calls (no custom token setup required)

## Changes Made

### twist-ai/.github/workflows/publish.yml
- Added step to capture published version after npm publish
- Added step to trigger twist-ai-integrations via GitHub's repository_dispatch API
- Includes fail-safe error handling (`continue-on-error: true`)
- Passes specific version and npm tag to target workflow

## Implementation Details

- **Trigger mechanism**: Uses GitHub's `repository_dispatch` API with event type `twist-ai-updated`
- **Version handling**: Sends exact published version, not just "latest"
- **Error isolation**: twist-ai publishing succeeds even if cross-repo trigger fails
- **Authentication**: Leverages existing organizational `GITHUB_TOKEN`


🤖 Generated with [Claude Code](https://claude.com/claude-code)