### PR TITLE
chore: Switches from deprecated zod code

### DIFF
--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -171,13 +171,13 @@ export const GetWorkspacesOutputSchema = z.object({
             creator: z.number(),
             creatorName: z.string().optional(),
             created: z.string(),
-            workspaceUrl: z.string().url(),
+            workspaceUrl: z.url(),
             defaultChannel: z.number().optional(),
             defaultChannelName: z.string().optional(),
-            defaultChannelUrl: z.string().url().optional(),
+            defaultChannelUrl: z.url().optional(),
             defaultConversation: z.number().optional(),
             defaultConversationTitle: z.string().optional(),
-            defaultConversationUrl: z.string().url().optional(),
+            defaultConversationUrl: z.url().optional(),
             plan: z.string().optional(), // WorkspacePlan is a string union
             avatarId: z.string().optional(),
             avatarUrls: z


### PR DESCRIPTION
Doing `z.string().url()` is deprecated and should be `z.url()`. I missed this when the code was added. 