### PR TITLE
fix: bump @doist/twist-sdk to 2.0.1 to fix missing url on batched list results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "4.2.0",
             "license": "MIT",
             "dependencies": {
-                "@doist/twist-sdk": "2.0.0",
+                "@doist/twist-sdk": "2.0.1",
                 "dotenv": "17.2.3",
                 "zod": "4.1.13"
             },
@@ -691,9 +691,9 @@
             }
         },
         "node_modules/@doist/twist-sdk": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.0.0.tgz",
-            "integrity": "sha512-hgucC0C+e4UgW1p6LdYvk93QVVjxWxMqtBRoyrma7IAG6OGz5tI01nNf32kP7EHJuRbQgSq/ARZlpej6CnAfcg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.0.1.tgz",
+            "integrity": "sha512-th+iydjV8tMePzaddq/iAaQVBU/5HK2gzo3V1UbMfbZdsWuVO6p9/Na4UdpAI/uFsAcDN2Bv1hYM1mv5MhbD9g==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "check:fix": "biome check --fix --unsafe"
     },
     "dependencies": {
-        "@doist/twist-sdk": "2.0.0",
+        "@doist/twist-sdk": "2.0.1",
         "dotenv": "17.2.3",
         "zod": "4.1.13"
     },


### PR DESCRIPTION
## Summary

- Bumps `@doist/twist-sdk` from `2.0.0` to `2.0.1` to fix missing `.url` on entities returned by batch list endpoints

## Context

[#99](https://github.com/Doist/twist-ai/pull/99) upgraded to `@doist/twist-sdk` v2.0.0 and replaced all manual `getFullTwistURL()` calls with `entity.url` (computed by Zod `.transform()`). However, v2.0.0 had a regression ([Doist/twist-sdk-typescript@87409cd](https://github.com/Doist/twist-sdk-typescript/commit/87409cd69dbd0a50a305a7d12713bc050d0db709)) where batch descriptors for list endpoints (`getInbox`, `getComments`, `getMessages`, `getConversations`, `getThreads`, `getChannels`) were missing the `schema` property. This meant the batch executor skipped the Zod parse and `.url` was `undefined` at runtime.

[v2.0.1](https://github.com/Doist/twist-sdk-typescript/releases/tag/v2.0.1) fixes this by adding `schema` to all list endpoint batch descriptors.

No local code changes needed — the code in this repo is already correct.

## Test plan

- [x] All 107 tests pass
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)