### PR TITLE
fix: suppress dotenv@17 stdout logging that breaks stdio MCP transport

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -23,5 +23,5 @@ function main() {
         })
 }
 
-dotenv.config()
+dotenv.config({ quiet: true })
 main()


### PR DESCRIPTION
## Summary

- `dotenv@17` logs a message to stdout by default when loading `.env` files, which corrupts the MCP stdio protocol (client receives non-JSON data and closes with error `-32002: connection closed`)
- Pass `{ quiet: true }` to `dotenv.config()` in `main.ts` to suppress the output
- Same fix as Doist/todoist-ai#306

## Test plan

- [x] All 107 tests pass
- [ ] Manual: verify MCP stdio transport connects successfully with a `.env` file present

🤖 Generated with [Claude Code](https://claude.com/claude-code)