### PR TITLE
chore: Auto-request Frontend Product reviewer on PRs

### DIFF
--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -1,0 +1,20 @@
+name: Automatically request reviews
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  request-reviews-frontend-product:
+    runs-on: ubuntu-latest
+    if: |
+      !github.event.pull_request.draft &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'renovate[bot]'
+    steps:
+      - name: Automatically request reviews from Frontend Product
+        uses: doist/auto-request-reviews-action@v1
+        with:
+          reviewers: 1
+          team: 'Doist/frontend-product'
+          token: ${{ secrets.GH_PROJECTS_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a workflow that automatically requests 1 reviewer from `Doist/frontend-product` on every non-draft, non-bot PR
- Same setup as [Doist/aist#1169](https://github.com/Doist/aist/pull/1169)

## Test plan
- [ ] Verify `GH_PROJECTS_TOKEN` secret is available (org-level)
- [ ] Merge and confirm reviewer is assigned on next PR