### PR TITLE
fix: add fallback URL construction when SDK batch validation strips .url

### DIFF
--- a/src/tools/fetch-inbox.ts
+++ b/src/tools/fetch-inbox.ts
@@ -5,6 +5,7 @@ import type {
     UnreadConversation,
     WorkspaceUser,
 } from '@doist/twist-sdk'
+import { getFullTwistURL } from '@doist/twist-sdk'
 import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TwistTool } from '../twist-tool.js'
@@ -274,7 +275,9 @@ const fetchInbox = {
                 creator: t.creator,
                 isUnread: t.isUnread,
                 isStarred: t.starred,
-                threadUrl: t.url,
+                threadUrl:
+                    t.url ??
+                    getFullTwistURL({ workspaceId, channelId: t.channelId, threadId: t.id }),
             })),
             conversations: conversationsWithDetails.map((cd) => {
                 const { conversation, participants } = cd
@@ -288,7 +291,12 @@ const fetchInbox = {
                     userIds: conversation.userIds,
                     participantNames,
                     isUnread: cd.isUnread,
-                    conversationUrl: conversation.url,
+                    conversationUrl:
+                        conversation.url ??
+                        getFullTwistURL({
+                            workspaceId: conversation.workspaceId,
+                            conversationId: conversation.id,
+                        }),
                 }
             }),
             unreadCount: unreadThreads.length,

--- a/src/tools/load-conversation.ts
+++ b/src/tools/load-conversation.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceUser } from '@doist/twist-sdk'
+import { getFullTwistURL, type WorkspaceUser } from '@doist/twist-sdk'
 import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TwistTool } from '../twist-tool.js'
@@ -139,7 +139,12 @@ const loadConversation = {
                 userIds: includeParticipants ? conversation.userIds : [],
                 archived: conversation.archived,
                 lastActive: conversation.lastActive.toISOString(),
-                conversationUrl: conversation.url,
+                conversationUrl:
+                    conversation.url ??
+                    getFullTwistURL({
+                        workspaceId: conversation.workspaceId,
+                        conversationId: conversation.id,
+                    }),
             },
             messages: messages.map((m) => ({
                 id: m.id,
@@ -148,7 +153,13 @@ const loadConversation = {
                 creatorName: userInfo[m.creator]?.name,
                 conversationId: m.conversationId,
                 posted: m.posted.toISOString(),
-                messageUrl: m.url,
+                messageUrl:
+                    m.url ??
+                    getFullTwistURL({
+                        workspaceId: m.workspaceId,
+                        conversationId: m.conversationId,
+                        messageId: m.id,
+                    }),
             })),
             totalMessages: conversation.messageCount ?? 0,
         }

--- a/src/tools/load-thread.ts
+++ b/src/tools/load-thread.ts
@@ -1,3 +1,4 @@
+import { getFullTwistURL } from '@doist/twist-sdk'
 import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TwistTool } from '../twist-tool.js'
@@ -184,7 +185,13 @@ const loadThread = {
                               .map((id) => userLookup[id])
                               .filter((name): name is string => name !== undefined)
                         : undefined,
-                threadUrl: thread.url,
+                threadUrl:
+                    thread.url ??
+                    getFullTwistURL({
+                        workspaceId: thread.workspaceId,
+                        channelId: thread.channelId,
+                        threadId: thread.id,
+                    }),
             },
             comments: comments.map((c) => ({
                 id: c.id,
@@ -193,7 +200,14 @@ const loadThread = {
                 creatorName: userLookup[c.creator],
                 threadId: c.threadId,
                 posted: c.posted.toISOString(),
-                commentUrl: c.url,
+                commentUrl:
+                    c.url ??
+                    getFullTwistURL({
+                        workspaceId: c.workspaceId,
+                        channelId: c.channelId,
+                        threadId: c.threadId,
+                        commentId: c.id,
+                    }),
             })),
             totalComments: thread.commentCount,
         }

--- a/src/tools/react.ts
+++ b/src/tools/react.ts
@@ -1,3 +1,4 @@
+import { getFullTwistURL } from '@doist/twist-sdk'
 import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TwistTool } from '../twist-tool.js'
@@ -42,14 +43,33 @@ const react = {
         // Fetch target metadata to get URL
         if (targetType === 'thread') {
             const thread = await client.threads.getThread(targetId)
-            targetUrl = thread.url
+            targetUrl =
+                thread.url ??
+                getFullTwistURL({
+                    workspaceId: thread.workspaceId,
+                    channelId: thread.channelId,
+                    threadId: thread.id,
+                })
         } else if (targetType === 'comment') {
             const comment = await client.comments.getComment(targetId)
-            targetUrl = comment.url
+            targetUrl =
+                comment.url ??
+                getFullTwistURL({
+                    workspaceId: comment.workspaceId,
+                    channelId: comment.channelId,
+                    threadId: comment.threadId,
+                    commentId: comment.id,
+                })
         } else {
             // message
             const message = await client.conversationMessages.getMessage(targetId)
-            targetUrl = message.url
+            targetUrl =
+                message.url ??
+                getFullTwistURL({
+                    workspaceId: message.workspaceId,
+                    conversationId: message.conversationId,
+                    messageId: message.id,
+                })
         }
 
         // Map targetType to the appropriate API parameter

--- a/src/tools/reply.ts
+++ b/src/tools/reply.ts
@@ -1,3 +1,4 @@
+import { getFullTwistURL } from '@doist/twist-sdk'
 import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TwistTool } from '../twist-tool.js'
@@ -49,7 +50,14 @@ const reply = {
                 recipients,
             })
             replyId = comment.id
-            replyUrl = comment.url
+            replyUrl =
+                comment.url ??
+                getFullTwistURL({
+                    workspaceId: comment.workspaceId,
+                    channelId: comment.channelId,
+                    threadId: comment.threadId,
+                    commentId: comment.id,
+                })
             const postedValue = comment.posted
             created = postedValue
                 ? typeof postedValue === 'string'
@@ -62,7 +70,13 @@ const reply = {
                 content,
             })
             replyId = message.id
-            replyUrl = message.url
+            replyUrl =
+                message.url ??
+                getFullTwistURL({
+                    workspaceId: message.workspaceId,
+                    conversationId: message.conversationId,
+                    messageId: message.id,
+                })
             const postedValue = message.posted
             created = postedValue
                 ? typeof postedValue === 'string'


### PR DESCRIPTION
## Summary

- Adds `?? getFullTwistURL(...)` fallback in all 5 tools (`fetch-inbox`, `load-thread`, `load-conversation`, `reply`, `react`) so that when the SDK's batch-builder silently drops `.url` due to Zod validation failures, the tools still return valid URLs
- Mirrors the defensive pattern already established in `search-content.ts`
- Adds 2 new test cases in `fetch-inbox.test.ts` verifying the fallback works for both threads and conversations

## Context

The SDK's batch-builder catches Zod validation errors silently, returning raw API data without the `.url` transform applied. When any field in any entity fails validation, ALL entities in the batch response lose their `.url` field, causing tools to return `threadUrl: undefined` which violates the `z.string()` output schema.

## Test plan

- [x] All 109 existing tests pass
- [x] 2 new tests verify URL fallback for threads and conversations with missing `.url`
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)