### PR TITLE
chore(deps): upgrade TypeScript 5.9 to 6.0

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,12 +12,20 @@ export default {
             'ts-jest',
             {
                 useESM: true,
+                tsconfig: {
+                    moduleResolution: 'Bundler',
+                    ignoreDeprecations: '6.0',
+                },
             },
         ],
         '^.+\\.js$': [
             'ts-jest',
             {
                 useESM: true,
+                tsconfig: {
+                    moduleResolution: 'Bundler',
+                    ignoreDeprecations: '6.0',
+                },
             },
         ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "nodemon": "3.1.14",
                 "rimraf": "6.1.3",
                 "ts-jest": "29.4.6",
-                "typescript": "5.9.3"
+                "typescript": "6.0.2"
             },
             "peerDependencies": {
                 "@modelcontextprotocol/sdk": "^1.25.0"
@@ -5941,9 +5941,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+            "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
     "peerDependencies": {
         "@modelcontextprotocol/sdk": "^1.25.0"
     },
+    "overrides": {
+        "ts-jest": {
+            "typescript": "$typescript"
+        }
+    },
     "devDependencies": {
         "@biomejs/biome": "2.4.7",
         "@types/jest": "30.0.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
         "nodemon": "3.1.14",
         "rimraf": "6.1.3",
         "ts-jest": "29.4.6",
-        "typescript": "5.9.3"
+        "typescript": "6.0.2"
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
 
         /* Modules */
         "module": "ESNext",
-        "moduleResolution": "Node",
+        "moduleResolution": "Bundler",
         "allowImportingTsExtensions": false,
         "rootDir": "src",
         "outDir": "dist",
@@ -22,12 +22,12 @@
         "noImplicitOverride": true,
 
         /* Interop */
-        "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "verbatimModuleSyntax": false,
         "isolatedModules": true,
 
         /* Other */
+        "types": ["node", "jest"],
         "skipLibCheck": true,
         "declaration": true,
         "declarationMap": false


### PR DESCRIPTION
## Summary
- Upgrade TypeScript from 5.9.3 to 6.0.2 (bridge release toward native TS 7.0)
- Migrate `moduleResolution` from `node` to `bundler` (`node`/`node10` deprecated in TS6)
- Remove redundant `"esModuleInterop": true` (always enabled in TS6)
- Add explicit `"types": ["node", "jest"]` (TS6 defaults `types` to `[]`)
- Override ts-jest config with `moduleResolution: "Bundler"` and `ignoreDeprecations: "6.0"` for ESM preset compatibility

## Notes
- `ts-jest@29.4.6` has a peer dependency of `typescript <6` — tests pass fine but there's an npm peer dep warning. ts-jest will need a release to officially support TS6.
- ts-jest emits `esModuleInterop` warnings because it doesn't yet know TS6 always enables it — these are harmless.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run build` succeeds
- [x] `npm test` — all 143 tests pass
- [x] `npm run lint:check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)