### PR TITLE
chore: Simplify release announcement

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,7 +87,6 @@ jobs:
 
           package_url="https://www.npmjs.com/package/${package_name}/v/${package_version}"
           release_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${release_tag}"
-          published_at="$(date -u +'%Y-%m-%d %H:%M:%S UTC')"
           previous_tag="$(git describe --tags --abbrev=0 "${release_sha}^" 2>/dev/null || true)"
 
           if [ -n "${previous_tag}" ]; then
@@ -109,9 +108,7 @@ jobs:
             echo "package_url=${package_url}"
             echo "release_url=${release_url}"
             echo "message<<EOF"
-            echo "🎉 **${package_name} ${release_tag} Published** (${published_at})"
-            echo
-            echo "📝 Changes"
+            echo "🎉 **Twist MCP & Tools ${release_tag} published** 🚀"
             echo
             printf '%s\n' "${changelog}"
             echo


### PR DESCRIPTION
More human-readable announcements. Going from

<img width="1236" height="624" alt="CleanShot 2026-03-23 at 21 47 53@2x" src="https://github.com/user-attachments/assets/b0922823-8684-4a5a-b4b7-68204a807daa" />

To:

<img width="1270" height="508" alt="CleanShot 2026-03-23 at 21 48 29@2x" src="https://github.com/user-attachments/assets/58ff584e-137c-4bc2-9b85-bf82c37adb08" />
