### PR TITLE
fix: add prepublishOnly script for release safety

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,12 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
+            - name: Build
+              run: npm run build
+
+            - name: Run tests
+              run: npm test
+
             - name: Capture previous tag
               id: previous_tag
               run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || true)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,6 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
-            - name: Build
-              run: npm run build
-
-            - name: Run tests
-              run: npm test
-
             - name: Capture previous tag
               id: previous_tag
               run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || true)" >> "$GITHUB_OUTPUT"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
         "format:check": "biome format",
         "format:write": "biome format --write",
         "check": "biome check",
-        "check:fix": "biome check --fix --unsafe"
+        "check:fix": "biome check --fix --unsafe",
+        "prepublishOnly": "npm run build && npm test"
     },
     "dependencies": {
         "@doist/twist-sdk": "2.1.2",


### PR DESCRIPTION
## Summary
Add `prepublishOnly` script to `package.json` to ensure the package is always built and tested before publishing — whether from semantic-release in CI or a manual `npm publish`.

## Changes
- Add `"prepublishOnly": "npm run build && npm test"` to `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)