### PR TITLE
chore: use GitHub App token for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,23 @@ jobs:
         timeout-minutes: 60
 
         steps:
+            - name: Generate bot token
+              id: generate_token
+              uses: actions/create-github-app-token@v1
+              with:
+                  app-id: ${{ secrets.DOIST_RELEASE_BOT_ID }}
+                  private-key: ${{ secrets.DOIST_RELEASE_BOT_PRIVATE_KEY }}
+
+            - name: Get bot user ID
+              id: bot_user
+              run: echo "id=$(gh api "/users/${{ steps.generate_token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+              env:
+                  GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
             - name: Checkout repository
               uses: actions/checkout@v4
               with:
-                  token: ${{ secrets.GH_REPO_TOKEN }}
+                  token: ${{ steps.generate_token.outputs.token }}
                   fetch-depth: 0
 
             - name: Setup Node.js
@@ -52,11 +65,11 @@ jobs:
             - name: Release
               run: npx semantic-release
               env:
-                  GITHUB_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
-                  GIT_AUTHOR_EMAIL: doistbot@users.noreply.github.com
-                  GIT_AUTHOR_NAME: Doist Bot
-                  GIT_COMMITTER_EMAIL: doistbot@users.noreply.github.com
-                  GIT_COMMITTER_NAME: Doist Bot
+                  GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+                  GIT_AUTHOR_NAME: ${{ steps.generate_token.outputs.app-slug }}[bot]
+                  GIT_AUTHOR_EMAIL: ${{ steps.bot_user.outputs.id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com
+                  GIT_COMMITTER_NAME: ${{ steps.generate_token.outputs.app-slug }}[bot]
+                  GIT_COMMITTER_EMAIL: ${{ steps.bot_user.outputs.id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com
 
             - name: Derive release announcement
               id: announcement

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,17 @@ jobs:
               with:
                   app-id: ${{ secrets.DOIST_RELEASE_BOT_ID }}
                   private-key: ${{ secrets.DOIST_RELEASE_BOT_PRIVATE_KEY }}
+                  permissions: contents:write, issues:write, pull-requests:write
 
             - name: Get bot user ID
               id: bot_user
-              run: echo "id=$(gh api "/users/${{ steps.generate_token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+              run: |
+                  user_id=$(gh api "/users/${{ steps.generate_token.outputs.app-slug }}[bot]" --jq .id)
+                  if [ -z "$user_id" ]; then
+                      echo "Failed to get bot user ID" >&2
+                      exit 1
+                  fi
+                  echo "id=$user_id" >> "$GITHUB_OUTPUT"
               env:
                   GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         steps:
             - name: Generate bot token
               id: generate_token
-              uses: actions/create-github-app-token@v1
+              uses: actions/create-github-app-token@v3
               with:
                   app-id: ${{ secrets.DOIST_RELEASE_BOT_ID }}
                   private-key: ${{ secrets.DOIST_RELEASE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
Replace `GH_REPO_TOKEN` (PAT) with a dynamically generated short-lived token from the `doist-release-bot` GitHub App via `actions/create-github-app-token@v1`.

## Changes
- Add `Generate bot token` step using `actions/create-github-app-token@v1`
- Add `Get bot user ID` step to derive the bot's noreply email address
- Replace `secrets.GH_REPO_TOKEN` with the generated token
- Replace hardcoded Doist Bot identity with dynamic identity from the GitHub App

## Pre-merge checklist
- [ ] `DOIST_RELEASE_BOT_ID` and `DOIST_RELEASE_BOT_PRIVATE_KEY` secrets are configured
- [ ] `doist-release-bot` app is installed on this repo and added as bypass actor on the branch ruleset

Part of https://github.com/Doist/todoist-web/issues/16941

🤖 Generated with [Claude Code](https://claude.com/claude-code)