### PR TITLE
feat: add update-thread and update-comment tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { markDone } from './tools/mark-done.js'
 import { react } from './tools/react.js'
 import { reply } from './tools/reply.js'
 import { searchContent } from './tools/search-content.js'
+import { updateComment } from './tools/update-comment.js'
+import { updateThread } from './tools/update-thread.js'
 import { userInfo } from './tools/user-info.js'
 
 const tools = {
@@ -20,6 +22,8 @@ const tools = {
     loadConversation,
     searchContent,
     createThread,
+    updateThread,
+    updateComment,
     reply,
     react,
     markDone,
@@ -37,6 +41,8 @@ export {
     loadConversation,
     searchContent,
     createThread,
+    updateThread,
+    updateComment,
     reply,
     react,
     markDone,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -14,6 +14,8 @@ import { markDone } from './tools/mark-done.js'
 import { react } from './tools/react.js'
 import { reply } from './tools/reply.js'
 import { searchContent } from './tools/search-content.js'
+import { updateComment } from './tools/update-comment.js'
+import { updateThread } from './tools/update-thread.js'
 import { userInfo } from './tools/user-info.js'
 
 const instructions = `
@@ -73,6 +75,8 @@ function getMcpServer({ twistApiKey, baseUrl }: { twistApiKey: string; baseUrl?:
     registerTool(searchContent, server, twist)
     registerTool(buildLink, server, twist)
     registerTool(createThread, server, twist)
+    registerTool(updateThread, server, twist)
+    registerTool(updateComment, server, twist)
     registerTool(reply, server, twist)
     registerTool(react, server, twist)
     registerTool(markDone, server, twist)

--- a/src/tools/__tests__/__snapshots__/update-comment.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/update-comment.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`update-comment tool updating comments should update a comment content 1`] = `
+"# Comment Updated
+
+**Comment ID:** 54321
+**Thread ID:** 12345
+**Channel ID:** 67890
+**Last Edited:** 2025-02-03T12:34:56.000Z
+**URL:** https://twist.com/a/11111/ch/67890/t/12345/c/54321
+
+## Content
+
+Updated comment content"
+`;

--- a/src/tools/__tests__/__snapshots__/update-thread.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/update-thread.test.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`update-thread tool updating threads should update a thread title and content 1`] = `
+"# Thread Updated
+
+**Title:** Updated Title
+**Thread ID:** 12345
+**Channel ID:** 67890
+**Last Edited:** 2025-02-03T12:34:56.000Z
+**URL:** https://twist.com/a/11111/ch/67890/t/12345/
+
+## Content
+
+Updated content"
+`;
+
+exports[`update-thread tool updating threads should update only the thread content 1`] = `
+"# Thread Updated
+
+**Title:** Test Thread
+**Thread ID:** 12345
+**Channel ID:** 67890
+**URL:** https://twist.com/a/11111/ch/67890/t/12345/
+
+## Content
+
+New content only"
+`;
+
+exports[`update-thread tool updating threads should update only the thread title 1`] = `
+"# Thread Updated
+
+**Title:** New Title Only
+**Thread ID:** 12345
+**Channel ID:** 67890
+**URL:** https://twist.com/a/11111/ch/67890/t/12345/
+
+## Content
+
+Test thread content"
+`;

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -83,6 +83,20 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         idempotentHint: false,
     },
     {
+        name: ToolNames.UPDATE_THREAD,
+        title: 'Twist: Update Thread',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    {
+        name: ToolNames.UPDATE_COMMENT,
+        title: 'Twist: Update Comment',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    {
         name: ToolNames.REPLY,
         title: 'Twist: Reply',
         readOnlyHint: false,

--- a/src/tools/__tests__/update-comment.test.ts
+++ b/src/tools/__tests__/update-comment.test.ts
@@ -1,0 +1,76 @@
+import type { TwistApi } from '@doist/twist-sdk'
+import { jest } from '@jest/globals'
+import { createMockComment, extractTextContent, TEST_IDS } from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { updateComment } from '../update-comment.js'
+
+const mockTwistApi = {
+    comments: {
+        updateComment: jest.fn(),
+    },
+} as unknown as jest.Mocked<TwistApi>
+
+const { UPDATE_COMMENT } = ToolNames
+
+describe(`${UPDATE_COMMENT} tool`, () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('updating comments', () => {
+        it('should update a comment content', async () => {
+            const mockComment = createMockComment({
+                content: 'Updated comment content',
+                lastEdited: new Date('2025-02-03T12:34:56Z'),
+            })
+            mockTwistApi.comments.updateComment.mockResolvedValue(mockComment)
+
+            const result = await updateComment.execute(
+                {
+                    id: TEST_IDS.COMMENT_1,
+                    content: 'Updated comment content',
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.comments.updateComment).toHaveBeenCalledWith({
+                id: TEST_IDS.COMMENT_1,
+                content: 'Updated comment content',
+            })
+
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    type: 'update_comment_result',
+                    success: true,
+                    commentId: mockComment.id,
+                    threadId: mockComment.threadId,
+                    channelId: mockComment.channelId,
+                    workspaceId: mockComment.workspaceId,
+                    content: 'Updated comment content',
+                    commentUrl: expect.stringContaining('twist.com'),
+                    lastEdited: '2025-02-03T12:34:56.000Z',
+                }),
+            )
+        })
+    })
+
+    describe('error handling', () => {
+        it('should propagate API errors', async () => {
+            const apiError = new Error('Comment not found')
+            mockTwistApi.comments.updateComment.mockRejectedValue(apiError)
+
+            await expect(
+                updateComment.execute(
+                    {
+                        id: TEST_IDS.COMMENT_1,
+                        content: 'Updated content',
+                    },
+                    mockTwistApi,
+                ),
+            ).rejects.toThrow('Comment not found')
+        })
+    })
+})

--- a/src/tools/__tests__/update-thread.test.ts
+++ b/src/tools/__tests__/update-thread.test.ts
@@ -1,0 +1,163 @@
+import type { TwistApi } from '@doist/twist-sdk'
+import { jest } from '@jest/globals'
+import { createMockThread, extractTextContent, TEST_IDS } from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { updateThread } from '../update-thread.js'
+
+const mockTwistApi = {
+    threads: {
+        updateThread: jest.fn(),
+    },
+} as unknown as jest.Mocked<TwistApi>
+
+const { UPDATE_THREAD } = ToolNames
+
+describe(`${UPDATE_THREAD} tool`, () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('updating threads', () => {
+        it('should update a thread title and content', async () => {
+            const mockThread = createMockThread({
+                title: 'Updated Title',
+                content: 'Updated content',
+                lastEdited: new Date('2025-02-03T12:34:56Z'),
+            })
+            mockTwistApi.threads.updateThread.mockResolvedValue(mockThread)
+
+            const result = await updateThread.execute(
+                {
+                    id: TEST_IDS.THREAD_1,
+                    title: 'Updated Title',
+                    content: 'Updated content',
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.threads.updateThread).toHaveBeenCalledWith({
+                id: TEST_IDS.THREAD_1,
+                title: 'Updated Title',
+                content: 'Updated content',
+            })
+
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    type: 'update_thread_result',
+                    success: true,
+                    threadId: mockThread.id,
+                    title: 'Updated Title',
+                    channelId: TEST_IDS.CHANNEL_1,
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                    content: 'Updated content',
+                    threadUrl: expect.stringContaining('twist.com'),
+                    lastEdited: '2025-02-03T12:34:56.000Z',
+                }),
+            )
+        })
+
+        it('should update only the thread title', async () => {
+            const mockThread = createMockThread({
+                title: 'New Title Only',
+            })
+            mockTwistApi.threads.updateThread.mockResolvedValue(mockThread)
+
+            const result = await updateThread.execute(
+                {
+                    id: TEST_IDS.THREAD_1,
+                    title: 'New Title Only',
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.threads.updateThread).toHaveBeenCalledWith({
+                id: TEST_IDS.THREAD_1,
+                title: 'New Title Only',
+                content: undefined,
+            })
+
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    type: 'update_thread_result',
+                    success: true,
+                    threadId: mockThread.id,
+                    title: 'New Title Only',
+                    channelId: TEST_IDS.CHANNEL_1,
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                    content: mockThread.content,
+                    threadUrl: expect.stringContaining('twist.com'),
+                }),
+            )
+        })
+
+        it('should update only the thread content', async () => {
+            const mockThread = createMockThread({
+                content: 'New content only',
+            })
+            mockTwistApi.threads.updateThread.mockResolvedValue(mockThread)
+
+            const result = await updateThread.execute(
+                {
+                    id: TEST_IDS.THREAD_1,
+                    content: 'New content only',
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.threads.updateThread).toHaveBeenCalledWith({
+                id: TEST_IDS.THREAD_1,
+                title: undefined,
+                content: 'New content only',
+            })
+
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    type: 'update_thread_result',
+                    success: true,
+                    threadId: mockThread.id,
+                    title: mockThread.title,
+                    channelId: TEST_IDS.CHANNEL_1,
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                    content: 'New content only',
+                    threadUrl: expect.stringContaining('twist.com'),
+                }),
+            )
+        })
+    })
+
+    describe('validation', () => {
+        it('should throw when neither title nor content is provided', async () => {
+            await expect(
+                updateThread.execute({ id: TEST_IDS.THREAD_1 }, mockTwistApi),
+            ).rejects.toThrow('At least one of `title` or `content` must be provided.')
+
+            expect(mockTwistApi.threads.updateThread).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('error handling', () => {
+        it('should propagate API errors', async () => {
+            const apiError = new Error('Thread not found')
+            mockTwistApi.threads.updateThread.mockRejectedValue(apiError)
+
+            await expect(
+                updateThread.execute(
+                    {
+                        id: TEST_IDS.THREAD_1,
+                        title: 'Updated Title',
+                    },
+                    mockTwistApi,
+                ),
+            ).rejects.toThrow('Thread not found')
+        })
+    })
+})

--- a/src/tools/update-comment.ts
+++ b/src/tools/update-comment.ts
@@ -1,0 +1,72 @@
+import { getFullTwistURL } from '@doist/twist-sdk'
+import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TwistTool } from '../twist-tool.js'
+import { type UpdateCommentOutput, UpdateCommentOutputSchema } from '../utils/output-schemas.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    id: z.number().describe('The ID of the comment to update.'),
+    content: z.string().min(1).describe('The new content for the comment.'),
+}
+
+const updateComment = {
+    name: ToolNames.UPDATE_COMMENT,
+    description:
+        "Update an existing comment's content. Requires the comment ID and the new content.",
+    parameters: ArgsSchema,
+    outputSchema: UpdateCommentOutputSchema.shape,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    async execute(args, client) {
+        const { id, content } = args
+
+        const comment = await client.comments.updateComment({
+            id,
+            content,
+        })
+
+        const commentUrl =
+            comment.url ??
+            getFullTwistURL({
+                workspaceId: comment.workspaceId,
+                channelId: comment.channelId,
+                threadId: comment.threadId,
+                commentId: comment.id,
+            })
+
+        const lastEdited = comment.lastEdited ? comment.lastEdited.toISOString() : undefined
+
+        const lines: string[] = [
+            `# Comment Updated`,
+            '',
+            `**Comment ID:** ${comment.id}`,
+            `**Thread ID:** ${comment.threadId}`,
+            `**Channel ID:** ${comment.channelId}`,
+            ...(lastEdited ? [`**Last Edited:** ${lastEdited}`] : []),
+            `**URL:** ${commentUrl}`,
+            '',
+            '## Content',
+            '',
+            comment.content,
+        ]
+
+        const structuredContent: UpdateCommentOutput = {
+            type: 'update_comment_result',
+            success: true,
+            commentId: comment.id,
+            threadId: comment.threadId,
+            channelId: comment.channelId,
+            workspaceId: comment.workspaceId,
+            content: comment.content,
+            commentUrl,
+            lastEdited,
+        }
+
+        return getToolOutput({
+            textContent: lines.join('\n'),
+            structuredContent,
+        })
+    },
+} satisfies TwistTool<typeof ArgsSchema, typeof UpdateCommentOutputSchema.shape>
+
+export { updateComment }

--- a/src/tools/update-thread.ts
+++ b/src/tools/update-thread.ts
@@ -1,0 +1,77 @@
+import { getFullTwistURL } from '@doist/twist-sdk'
+import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TwistTool } from '../twist-tool.js'
+import { type UpdateThreadOutput, UpdateThreadOutputSchema } from '../utils/output-schemas.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    id: z.number().describe('The ID of the thread to update.'),
+    title: z.string().min(1).optional().describe('The new title for the thread.'),
+    content: z.string().min(1).optional().describe('The new content/body for the thread.'),
+}
+
+const updateThread = {
+    name: ToolNames.UPDATE_THREAD,
+    description:
+        "Update an existing thread's title and/or content. Requires the thread ID and at least one of title or content to update.",
+    parameters: ArgsSchema,
+    outputSchema: UpdateThreadOutputSchema.shape,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    async execute(args, client) {
+        const { id, title, content } = args
+
+        if (title === undefined && content === undefined) {
+            throw new Error('At least one of `title` or `content` must be provided.')
+        }
+
+        const thread = await client.threads.updateThread({
+            id,
+            title,
+            content,
+        })
+
+        const threadUrl =
+            thread.url ??
+            getFullTwistURL({
+                workspaceId: thread.workspaceId,
+                channelId: thread.channelId,
+                threadId: thread.id,
+            })
+
+        const lastEdited = thread.lastEdited ? thread.lastEdited.toISOString() : undefined
+
+        const lines: string[] = [
+            `# Thread Updated`,
+            '',
+            `**Title:** ${thread.title}`,
+            `**Thread ID:** ${thread.id}`,
+            `**Channel ID:** ${thread.channelId}`,
+            ...(lastEdited ? [`**Last Edited:** ${lastEdited}`] : []),
+            `**URL:** ${threadUrl}`,
+            '',
+            '## Content',
+            '',
+            thread.content,
+        ]
+
+        const structuredContent: UpdateThreadOutput = {
+            type: 'update_thread_result',
+            success: true,
+            threadId: thread.id,
+            title: thread.title,
+            channelId: thread.channelId,
+            workspaceId: thread.workspaceId,
+            content: thread.content,
+            threadUrl,
+            lastEdited,
+        }
+
+        return getToolOutput({
+            textContent: lines.join('\n'),
+            structuredContent,
+        })
+    },
+} satisfies TwistTool<typeof ArgsSchema, typeof UpdateThreadOutputSchema.shape>
+
+export { updateThread }

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -282,6 +282,36 @@ export const CreateThreadOutputSchema = z.object({
 })
 
 /**
+ * Schema for update-thread tool output
+ */
+export const UpdateThreadOutputSchema = z.object({
+    type: z.literal('update_thread_result'),
+    success: z.boolean(),
+    threadId: z.number(),
+    title: z.string(),
+    channelId: z.number(),
+    workspaceId: z.number(),
+    content: z.string(),
+    threadUrl: z.string(),
+    lastEdited: z.string().nullable().optional(),
+})
+
+/**
+ * Schema for update-comment tool output
+ */
+export const UpdateCommentOutputSchema = z.object({
+    type: z.literal('update_comment_result'),
+    success: z.boolean(),
+    commentId: z.number(),
+    threadId: z.number(),
+    channelId: z.number(),
+    workspaceId: z.number(),
+    content: z.string(),
+    commentUrl: z.string(),
+    lastEdited: z.string().nullable().optional(),
+})
+
+/**
  * Schema for reply tool output
  */
 export const ReplyOutputSchema = z.object({
@@ -375,6 +405,8 @@ export const StructuredOutputSchema = z.union([
     UserInfoOutputSchema,
     BuildLinkOutputSchema,
     CreateThreadOutputSchema,
+    UpdateThreadOutputSchema,
+    UpdateCommentOutputSchema,
     ReplyOutputSchema,
     ReactOutputSchema,
     MarkDoneOutputSchema,
@@ -385,6 +417,8 @@ export const StructuredOutputSchema = z.union([
  * Type definitions for the structured outputs
  */
 export type CreateThreadOutput = z.infer<typeof CreateThreadOutputSchema>
+export type UpdateThreadOutput = z.infer<typeof UpdateThreadOutputSchema>
+export type UpdateCommentOutput = z.infer<typeof UpdateCommentOutputSchema>
 export type AwayOutput = z.infer<typeof AwayOutputSchema>
 export type LoadThreadOutput = z.infer<typeof LoadThreadOutputSchema>
 export type LoadConversationOutput = z.infer<typeof LoadConversationOutputSchema>

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -5,6 +5,8 @@ export const ToolNames = {
     LOAD_CONVERSATION: 'load-conversation',
     SEARCH_CONTENT: 'search-content',
     CREATE_THREAD: 'create-thread',
+    UPDATE_THREAD: 'update-thread',
+    UPDATE_COMMENT: 'update-comment',
     REPLY: 'reply',
     REACT: 'react',
     MARK_DONE: 'mark-done',


### PR DESCRIPTION
## Summary

- **Add `update-thread` tool** — allows editing a thread's title and/or content via `client.threads.updateThread()`. Both `title` and `content` are optional so users can update either or both fields.
- **Add `update-comment` tool** — allows editing a comment's content via `client.comments.updateComment()`.
- Update tool registry, exports, output schemas, tool names, and tool annotation tests to cover the new tools.

## Motivation

The existing toolset has create and read operations for threads and comments, but no update operations. This means users cannot fix typos, add missing links, or correct information in threads/comments they've already posted. These two tools fill that CRUD gap using the SDK's existing `updateThread` and `updateComment` methods.

## Implementation details

Both tools follow the exact patterns established by existing tools:

- Zod parameter schemas with `.describe()` for LLM comprehension
- Structured output schemas (`UpdateThreadOutputSchema`, `UpdateCommentOutputSchema`) registered in the union type
- Text + structured content dual output via `getToolOutput()`
- MCP annotations: `readOnlyHint: false`, `destructiveHint: false`, `idempotentHint: true`
- Full test coverage with mocked API calls and snapshot tests
- Registered in `mcp-server.ts` and exported from `index.ts`

## Test plan

- [x] All 153 tests pass (17 suites)
- [x] TypeScript type-check passes with no errors
- [x] Biome lint/format passes on all new files
- [x] Project builds successfully
- [x] New snapshot tests for update-thread (3 cases) and update-comment (1 case)
- [x] Tool annotation coverage test updated and passing