### PR TITLE
feat(fetch-inbox): add archiveFilter parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "4.5.2",
             "license": "MIT",
             "dependencies": {
-                "@doist/twist-sdk": "2.3.0",
+                "@doist/twist-sdk": "2.4.0",
                 "dotenv": "17.4.1",
                 "zod": "4.1.13"
             },
@@ -593,9 +593,9 @@
             }
         },
         "node_modules/@doist/twist-sdk": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.3.0.tgz",
-            "integrity": "sha512-WmuHQuhmEm0RWIBcvysYZxS5yHfHUi4S5AH28WmZVZkWINpvGqc+E2R6bHqPZngdsnQQgqji94pFM39fpIdkqA==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.4.0.tgz",
+            "integrity": "sha512-FWX0rGMHtCZwTaBvK+km4LSMJRR3caPuiWPYaYThQEvxtcthzrkAv1fqppW/ArVljPZkkvnNh78pv2dWZcT+6g==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "prepublishOnly": "npm run build && npm test"
     },
     "dependencies": {
-        "@doist/twist-sdk": "2.3.0",
+        "@doist/twist-sdk": "2.4.0",
         "dotenv": "17.4.1",
         "zod": "4.1.13"
     },
@@ -58,8 +58,6 @@
         }
     },
     "devDependencies": {
-        "oxfmt": "0.44.0",
-        "oxlint": "1.59.0",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "@types/jest": "30.0.0",
@@ -68,6 +66,8 @@
         "conventional-changelog-conventionalcommits": "9.3.1",
         "jest": "30.3.0",
         "nodemon": "3.1.14",
+        "oxfmt": "0.44.0",
+        "oxlint": "1.59.0",
         "rimraf": "6.1.3",
         "semantic-release": "25.0.3",
         "ts-jest": "29.4.9",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -29,6 +29,7 @@ You have access to comprehensive Twist management tools for team communication a
 
 ### Tool Usage Guidelines:
 
+- **fetch-inbox**: Use to fetch inbox threads for a workspace, along with unread conversations and counts. Supports archiveFilter values of active, archived, or all; use all when the user needs both open and done threads. Optionally set onlyUnread to focus on unread items.
 - **list-channels**: Use to discover channels in a workspace. Requires a workspace ID. Optionally set includeArchived to true to also list archived channels. Returns channel names, IDs, descriptions, visibility, archive status, and URLs.
 
 ### Best Practices:

--- a/src/tools/__tests__/fetch-inbox.test.ts
+++ b/src/tools/__tests__/fetch-inbox.test.ts
@@ -454,65 +454,170 @@ describe(`${FETCH_INBOX} tool`, () => {
             expect(structuredContent?.conversations).toHaveLength(0)
         })
 
-        it('should pass archiveFilter "all" to SDK', async () => {
-            mockTwistApi.inbox.getInbox.mockResolvedValue([])
-            mockTwistApi.inbox.getCount.mockResolvedValue(0)
-            mockTwistApi.threads.getUnread.mockResolvedValue([])
-            mockTwistApi.conversations.getUnread.mockResolvedValue([])
-
-            await fetchInbox.execute(
-                {
+        describe('archiveFilter', () => {
+            function createThread({
+                id,
+                title,
+                creator,
+                isArchived,
+            }: {
+                id: number
+                title: string
+                creator: number
+                isArchived: boolean
+            }) {
+                return {
+                    id,
+                    title,
+                    content: `${title} content`,
+                    creator,
+                    channelId: TEST_IDS.CHANNEL_1,
                     workspaceId: TEST_IDS.WORKSPACE_1,
-                    limit: 50,
-                    onlyUnread: false,
-                    archiveFilter: 'all',
-                },
-                mockTwistApi,
-            )
+                    commentCount: 1,
+                    lastUpdated: new Date(),
+                    posted: new Date(),
+                    snippet: `${title} snippet`,
+                    snippetCreator: creator,
+                    starred: false,
+                    pinned: false,
+                    isArchived,
+                    inInbox: true,
+                    closed: isArchived,
+                    url: `https://twist.com/a/${TEST_IDS.WORKSPACE_1}/ch/${TEST_IDS.CHANNEL_1}/t/${id}/`,
+                }
+            }
 
-            expect(mockTwistApi.inbox.getInbox).toHaveBeenCalledWith(
-                expect.objectContaining({ archiveFilter: 'all' }),
-                { batch: true },
-            )
-        })
-
-        it('should pass archiveFilter "archived" to SDK', async () => {
-            mockTwistApi.inbox.getInbox.mockResolvedValue([])
-            mockTwistApi.inbox.getCount.mockResolvedValue(0)
-            mockTwistApi.threads.getUnread.mockResolvedValue([])
-            mockTwistApi.conversations.getUnread.mockResolvedValue([])
-
-            await fetchInbox.execute(
-                {
+            function mockArchiveFilterInbox(threads: Array<ReturnType<typeof createThread>>) {
+                mockTwistApi.inbox.getInbox.mockResolvedValue(threads)
+                mockTwistApi.inbox.getCount.mockResolvedValue(0)
+                mockTwistApi.threads.getUnread.mockResolvedValue([])
+                mockTwistApi.conversations.getUnread.mockResolvedValue([])
+                mockTwistApi.channels.getChannel.mockResolvedValue({
+                    id: TEST_IDS.CHANNEL_1,
+                    name: 'Test Channel',
                     workspaceId: TEST_IDS.WORKSPACE_1,
-                    limit: 50,
-                    onlyUnread: false,
-                    archiveFilter: 'archived',
-                },
-                mockTwistApi,
-            )
+                    created: new Date(),
+                    archived: false,
+                    public: true,
+                    color: 0,
+                    creator: TEST_IDS.USER_1,
+                    version: 1,
+                })
+            }
 
-            expect(mockTwistApi.inbox.getInbox).toHaveBeenCalledWith(
-                expect.objectContaining({ archiveFilter: 'archived' }),
-                { batch: true },
-            )
-        })
+            it('should default to active threads', async () => {
+                mockArchiveFilterInbox([
+                    createThread({
+                        id: TEST_IDS.THREAD_1,
+                        title: 'Active Thread',
+                        creator: TEST_IDS.USER_1,
+                        isArchived: false,
+                    }),
+                ])
 
-        it('should default archiveFilter to "active"', async () => {
-            mockTwistApi.inbox.getInbox.mockResolvedValue([])
-            mockTwistApi.inbox.getCount.mockResolvedValue(0)
-            mockTwistApi.threads.getUnread.mockResolvedValue([])
-            mockTwistApi.conversations.getUnread.mockResolvedValue([])
+                const result = await fetchInbox.execute(
+                    { workspaceId: TEST_IDS.WORKSPACE_1, limit: 50, onlyUnread: false },
+                    mockTwistApi,
+                )
 
-            await fetchInbox.execute(
-                { workspaceId: TEST_IDS.WORKSPACE_1, limit: 50, onlyUnread: false },
-                mockTwistApi,
-            )
+                expect(mockTwistApi.inbox.getInbox).toHaveBeenCalledWith(
+                    expect.objectContaining({ archiveFilter: 'active' }),
+                    { batch: true },
+                )
+                const textContent = extractTextContent(result)
+                expect(textContent).toContain('Active Thread')
+                expect(textContent).not.toContain('Archived Thread')
+                expect(textContent).not.toContain('Active Thread [archived]')
+                expect(result.structuredContent?.threads).toEqual([
+                    expect.objectContaining({
+                        id: TEST_IDS.THREAD_1,
+                        isArchived: false,
+                    }),
+                ])
+            })
 
-            expect(mockTwistApi.inbox.getInbox).toHaveBeenCalledWith(
-                expect.objectContaining({ archiveFilter: 'active' }),
-                { batch: true },
-            )
+            it('should return archived threads when requested', async () => {
+                mockArchiveFilterInbox([
+                    createThread({
+                        id: TEST_IDS.THREAD_2,
+                        title: 'Archived Thread',
+                        creator: TEST_IDS.USER_2,
+                        isArchived: true,
+                    }),
+                ])
+
+                const result = await fetchInbox.execute(
+                    {
+                        workspaceId: TEST_IDS.WORKSPACE_1,
+                        limit: 50,
+                        onlyUnread: false,
+                        archiveFilter: 'archived',
+                    },
+                    mockTwistApi,
+                )
+
+                expect(mockTwistApi.inbox.getInbox).toHaveBeenCalledWith(
+                    expect.objectContaining({ archiveFilter: 'archived' }),
+                    { batch: true },
+                )
+                const textContent = extractTextContent(result)
+                expect(textContent).toContain('Archived Thread [archived]')
+                expect(textContent).not.toContain('Active Thread')
+                expect(result.structuredContent?.threads).toEqual([
+                    expect.objectContaining({
+                        id: TEST_IDS.THREAD_2,
+                        isArchived: true,
+                    }),
+                ])
+            })
+
+            it('should return active and archived threads when requested', async () => {
+                mockArchiveFilterInbox([
+                    createThread({
+                        id: TEST_IDS.THREAD_1,
+                        title: 'Active Thread',
+                        creator: TEST_IDS.USER_1,
+                        isArchived: false,
+                    }),
+                    createThread({
+                        id: TEST_IDS.THREAD_2,
+                        title: 'Archived Thread',
+                        creator: TEST_IDS.USER_2,
+                        isArchived: true,
+                    }),
+                ])
+
+                const result = await fetchInbox.execute(
+                    {
+                        workspaceId: TEST_IDS.WORKSPACE_1,
+                        limit: 50,
+                        onlyUnread: false,
+                        archiveFilter: 'all',
+                    },
+                    mockTwistApi,
+                )
+
+                expect(mockTwistApi.inbox.getInbox).toHaveBeenCalledWith(
+                    expect.objectContaining({ archiveFilter: 'all' }),
+                    { batch: true },
+                )
+                const textContent = extractTextContent(result)
+                expect(textContent).toContain('Active Thread')
+                expect(textContent).toContain('Archived Thread [archived]')
+                expect(textContent).not.toContain('Active Thread [archived]')
+                expect(result.structuredContent?.threads).toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({
+                            id: TEST_IDS.THREAD_1,
+                            isArchived: false,
+                        }),
+                        expect.objectContaining({
+                            id: TEST_IDS.THREAD_2,
+                            isArchived: true,
+                        }),
+                    ]),
+                )
+            })
         })
     })
 

--- a/src/tools/__tests__/fetch-inbox.test.ts
+++ b/src/tools/__tests__/fetch-inbox.test.ts
@@ -117,6 +117,7 @@ describe(`${FETCH_INBOX} tool`, () => {
                     since: undefined,
                     until: undefined,
                     limit: 50,
+                    archiveFilter: 'active',
                 },
                 { batch: true },
             )
@@ -451,6 +452,67 @@ describe(`${FETCH_INBOX} tool`, () => {
             const { structuredContent } = result
             expect(structuredContent?.totalConversations).toBe(0)
             expect(structuredContent?.conversations).toHaveLength(0)
+        })
+
+        it('should pass archiveFilter "all" to SDK', async () => {
+            mockTwistApi.inbox.getInbox.mockResolvedValue([])
+            mockTwistApi.inbox.getCount.mockResolvedValue(0)
+            mockTwistApi.threads.getUnread.mockResolvedValue([])
+            mockTwistApi.conversations.getUnread.mockResolvedValue([])
+
+            await fetchInbox.execute(
+                {
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                    limit: 50,
+                    onlyUnread: false,
+                    archiveFilter: 'all',
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.inbox.getInbox).toHaveBeenCalledWith(
+                expect.objectContaining({ archiveFilter: 'all' }),
+                { batch: true },
+            )
+        })
+
+        it('should pass archiveFilter "archived" to SDK', async () => {
+            mockTwistApi.inbox.getInbox.mockResolvedValue([])
+            mockTwistApi.inbox.getCount.mockResolvedValue(0)
+            mockTwistApi.threads.getUnread.mockResolvedValue([])
+            mockTwistApi.conversations.getUnread.mockResolvedValue([])
+
+            await fetchInbox.execute(
+                {
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                    limit: 50,
+                    onlyUnread: false,
+                    archiveFilter: 'archived',
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.inbox.getInbox).toHaveBeenCalledWith(
+                expect.objectContaining({ archiveFilter: 'archived' }),
+                { batch: true },
+            )
+        })
+
+        it('should default archiveFilter to "active"', async () => {
+            mockTwistApi.inbox.getInbox.mockResolvedValue([])
+            mockTwistApi.inbox.getCount.mockResolvedValue(0)
+            mockTwistApi.threads.getUnread.mockResolvedValue([])
+            mockTwistApi.conversations.getUnread.mockResolvedValue([])
+
+            await fetchInbox.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1, limit: 50, onlyUnread: false },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.inbox.getInbox).toHaveBeenCalledWith(
+                expect.objectContaining({ archiveFilter: 'active' }),
+                { batch: true },
+            )
         })
     })
 

--- a/src/tools/fetch-inbox.ts
+++ b/src/tools/fetch-inbox.ts
@@ -5,7 +5,7 @@ import type {
     UnreadConversation,
     WorkspaceUser,
 } from '@doist/twist-sdk'
-import { getFullTwistURL } from '@doist/twist-sdk'
+import { ARCHIVE_FILTER_VALUES, getFullTwistURL } from '@doist/twist-sdk'
 import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TwistTool } from '../twist-tool.js'
@@ -32,7 +32,7 @@ const ArgsSchema = {
         .describe('Maximum number of items to return.'),
     onlyUnread: z.boolean().optional().default(false).describe('Only return unread items.'),
     archiveFilter: z
-        .enum(['active', 'archived', 'all'])
+        .enum(ARCHIVE_FILTER_VALUES)
         .optional()
         .default('active')
         .describe(
@@ -53,6 +53,7 @@ type FetchInboxStructured = {
         channelName?: string
         creator: number
         isUnread: boolean
+        isArchived: boolean
         isStarred: boolean
         threadUrl: string
     }>
@@ -166,6 +167,7 @@ const fetchInbox = {
         let threads = inboxThreadsResponse.data.map((thread) => ({
             ...thread,
             isUnread: unreadThreadsDataResponse.data.some((ut) => ut.threadId === thread.id),
+            isArchived: thread.isArchived,
         }))
 
         const unreadThreads = threads.filter((t) => t.isUnread)
@@ -237,10 +239,11 @@ const fetchInbox = {
                 if (channel) {
                     thread.title = `[${channel.name}] ${thread.title}`
                 }
+                const archivedBadge = thread.isArchived ? ' [archived]' : ''
                 const unreadBadge = thread.isUnread ? ' 🔵' : ''
                 const starBadge = thread.starred ? ' ⭐' : ''
                 lines.push(
-                    `- ${thread.title}${unreadBadge}${starBadge}${channelDetails} (ID: ${thread.id})`,
+                    `- ${thread.title}${archivedBadge}${unreadBadge}${starBadge}${channelDetails} (ID: ${thread.id})`,
                 )
             }
             lines.push('')
@@ -286,6 +289,7 @@ const fetchInbox = {
                 channelName: channelInfo[t.channelId]?.name,
                 creator: t.creator,
                 isUnread: t.isUnread,
+                isArchived: t.isArchived,
                 isStarred: t.starred,
                 threadUrl:
                     t.url ??

--- a/src/tools/fetch-inbox.ts
+++ b/src/tools/fetch-inbox.ts
@@ -31,6 +31,16 @@ const ArgsSchema = {
         .default(50)
         .describe('Maximum number of items to return.'),
     onlyUnread: z.boolean().optional().default(false).describe('Only return unread items.'),
+    archiveFilter: z
+        .enum(['active', 'archived', 'all'])
+        .optional()
+        .default('active')
+        .describe(
+            'Filter inbox threads by archive status. ' +
+                '"active" (default) shows only current threads, ' +
+                '"archived" shows only done/archived threads, ' +
+                '"all" shows both active and done threads.',
+        ),
 }
 
 type FetchInboxStructured = {
@@ -122,12 +132,13 @@ async function loadConversationDetails(
 const fetchInbox = {
     name: ToolNames.FETCH_INBOX,
     description:
-        'Fetch inbox view with threads, conversations, unread counts, and unread IDs. Provides a complete picture of the inbox state.',
+        'Fetch inbox view with threads, conversations, unread counts, and unread IDs. Provides a complete picture of the inbox state. Use archiveFilter "all" to include threads marked as done alongside active threads.',
     parameters: ArgsSchema,
     outputSchema: FetchInboxOutputSchema.shape,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         const { workspaceId, sinceDate, untilDate, limit, onlyUnread } = args
+        const archiveFilter = args.archiveFilter ?? 'active'
 
         // Call all 4 endpoints in parallel for complete inbox picture
         const [
@@ -142,6 +153,7 @@ const fetchInbox = {
                     since: sinceDate ? new Date(sinceDate) : undefined,
                     until: untilDate ? new Date(untilDate) : undefined,
                     limit,
+                    archiveFilter,
                 },
                 { batch: true },
             ),

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -111,6 +111,7 @@ export const FetchInboxOutputSchema = z.object({
             channelName: z.string().optional(),
             creator: z.number(),
             isUnread: z.boolean(),
+            isArchived: z.boolean(),
             isStarred: z.boolean(),
             threadUrl: z.string(),
         }),


### PR DESCRIPTION
## Summary

Surfaces the existing `archive_filter` API parameter in the fetch-inbox MCP tool. Allows AI agents to fetch active, archived, or all inbox threads.

- Adds `archiveFilter` parameter to `fetch-inbox` tool (`'active'` | `'archived'` | `'all'`)
- Bumps `@doist/twist-sdk` to 2.4.0 (which added `archiveFilter` to `getInbox()`)
- Defaults to `'active'` (backward compatible)

## Use case

AI agents that poll the inbox need visibility into threads marked as done between polling intervals. With `archiveFilter: 'all'`, a single call returns both active and archived threads.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run format:check` passes
- [x] `npm test` — 146 tests pass (3 new)