### PR TITLE
docs(create-thread): clarify recipients default and creator inbox behavior

### DIFF
--- a/src/tools/__tests__/__snapshots__/create-thread.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/create-thread.test.ts.snap
@@ -11,7 +11,9 @@ exports[`create-thread tool creating threads should create a thread in a channel
 
 ## Content
 
-Let us discuss this topic"
+Let us discuss this topic
+
+> Note: Threads you create do not appear in your own Inbox by default — only recipients see them there. Find the thread in the channel view or via its URL."
 `;
 
 exports[`create-thread tool creating threads should create a thread with recipients 1`] = `
@@ -25,5 +27,7 @@ exports[`create-thread tool creating threads should create a thread with recipie
 
 ## Content
 
-Important update"
+Important update
+
+> Note: Threads you create do not appear in your own Inbox by default — only recipients see them there. Find the thread in the channel view or via its URL."
 `;

--- a/src/tools/create-thread.ts
+++ b/src/tools/create-thread.ts
@@ -13,7 +13,7 @@ const ArgsSchema = {
         .array(z.number())
         .optional()
         .describe(
-            'Optional array of user IDs to notify about the thread. If not provided, the channel default recipients will be used.',
+            'Optional array of user IDs to notify. If omitted, Twist defaults to notifying all current members of the channel (equivalent to the API\'s "EVERYONE" default). Note: workspace users who have not joined this channel will not be notified — add their IDs explicitly if you want to reach them.',
         ),
 }
 
@@ -61,6 +61,8 @@ const createThread = {
             '## Content',
             '',
             thread.content,
+            '',
+            '> Note: Threads you create do not appear in your own Inbox by default — only recipients see them there. Find the thread in the channel view or via its URL.',
         ]
 
         const structuredContent: CreateThreadOutput = {

--- a/src/tools/reply.ts
+++ b/src/tools/reply.ts
@@ -15,7 +15,9 @@ const ArgsSchema = {
     recipients: z
         .array(z.number())
         .optional()
-        .describe('Optional array of user IDs to notify (only for thread replies).'),
+        .describe(
+            'Optional array of user IDs to notify (only for thread replies). If omitted, Twist defaults to notifying all current members of the channel. Add specific user IDs to limit or expand notifications beyond current channel members.',
+        ),
 }
 
 type ReplyStructured = {


### PR DESCRIPTION
## Problem

The `recipients` field description in `create-thread` said:

> If not provided, the channel default recipients will be used.

This is misleading. "Channel default recipients" is not a concept that exists in the Twist API — it suggests there's some configurable default per channel. In reality, when `recipients` is omitted, the Twist API defaults to `EVERYONE`, meaning **all current members of the channel** are notified.

Two related issues:
1. Users reading "channel default recipients" often assume it means all workspace members — but Twist channels require explicit joining, so the actual reach is limited to channel members only.
2. Thread creators do not see their own new threads appear in their Inbox. When using this tool via an LLM assistant, this causes confusion: the LLM reports success, the user checks their Inbox, and sees nothing — leading them to think the thread wasn't created.

## Changes

**`src/tools/create-thread.ts`**
- Updated `recipients` description to explicitly name the `EVERYONE` API default and clarify that workspace users who haven't joined the channel must be added explicitly.
- Appended a note to the post-creation text output warning that thread creators won't see the new thread in their own Inbox.

**`src/tools/reply.ts`**
- Applied the same recipients clarification (without the creator-inbox note, which is thread-specific).

**`src/tools/__tests__/__snapshots__/create-thread.test.ts.snap`**
- Updated snapshots to include the new output line.

## Non-breaking

Description strings and text output only. No behavior changes, no API call changes, no new parameters.

## Testing

All 105 tests pass (2 pre-existing test suite failures in `fetch-inbox` and `tool-annotations` caused by an SDK/code mismatch on `ARCHIVE_FILTER_VALUES` — unrelated to this PR and reproducible on `main` without these changes).