### PR TITLE
feat: add send-direct-message and delete-item tools

### DIFF
--- a/scripts/run-tool.ts
+++ b/scripts/run-tool.ts
@@ -20,6 +20,7 @@ import { config } from 'dotenv'
 import { away } from '../src/tools/away.js'
 import { buildLink } from '../src/tools/build-link.js'
 import { createThread } from '../src/tools/create-thread.js'
+import { deleteItem } from '../src/tools/delete-item.js'
 import { fetchInbox } from '../src/tools/fetch-inbox.js'
 import { getUsers } from '../src/tools/get-users.js'
 import { getWorkspaces } from '../src/tools/get-workspaces.js'
@@ -30,6 +31,7 @@ import { markDone } from '../src/tools/mark-done.js'
 import { react } from '../src/tools/react.js'
 import { reply } from '../src/tools/reply.js'
 import { searchContent } from '../src/tools/search-content.js'
+import { sendDirectMessage } from '../src/tools/send-direct-message.js'
 import { userInfo } from '../src/tools/user-info.js'
 
 // Define a minimal type for tool execution that works with any tool
@@ -61,6 +63,8 @@ const tools: Record<string, ExecutableTool> = {
     'get-users': getUsers,
     away: away,
     'list-channels': listChannels,
+    'send-direct-message': sendDirectMessage,
+    'delete-item': deleteItem,
 }
 
 function printUsage() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { getMcpServer } from './mcp-server.js'
 import { away } from './tools/away.js'
 import { buildLink } from './tools/build-link.js'
 import { createThread } from './tools/create-thread.js'
+import { deleteItem } from './tools/delete-item.js'
 import { fetchInbox } from './tools/fetch-inbox.js'
 import { listChannels } from './tools/list-channels.js'
 import { loadConversation } from './tools/load-conversation.js'
@@ -10,6 +11,7 @@ import { markDone } from './tools/mark-done.js'
 import { react } from './tools/react.js'
 import { reply } from './tools/reply.js'
 import { searchContent } from './tools/search-content.js'
+import { sendDirectMessage } from './tools/send-direct-message.js'
 import { updateComment } from './tools/update-comment.js'
 import { updateThread } from './tools/update-thread.js'
 import { userInfo } from './tools/user-info.js'
@@ -29,6 +31,8 @@ const tools = {
     markDone,
     buildLink,
     listChannels,
+    sendDirectMessage,
+    deleteItem,
 }
 
 export { tools, getMcpServer }
@@ -48,4 +52,6 @@ export {
     markDone,
     buildLink,
     listChannels,
+    sendDirectMessage,
+    deleteItem,
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4,6 +4,7 @@ import { registerTool } from './mcp-helpers.js'
 import { away } from './tools/away.js'
 import { buildLink } from './tools/build-link.js'
 import { createThread } from './tools/create-thread.js'
+import { deleteItem } from './tools/delete-item.js'
 import { fetchInbox } from './tools/fetch-inbox.js'
 import { getUsers } from './tools/get-users.js'
 import { getWorkspaces } from './tools/get-workspaces.js'
@@ -14,6 +15,7 @@ import { markDone } from './tools/mark-done.js'
 import { react } from './tools/react.js'
 import { reply } from './tools/reply.js'
 import { searchContent } from './tools/search-content.js'
+import { sendDirectMessage } from './tools/send-direct-message.js'
 import { updateComment } from './tools/update-comment.js'
 import { updateThread } from './tools/update-thread.js'
 import { userInfo } from './tools/user-info.js'
@@ -33,6 +35,8 @@ You have access to comprehensive Twist management tools for team communication a
 
 - **fetch-inbox**: Use to fetch inbox threads for a workspace, along with unread conversations and counts. Supports archiveFilter values of active, archived, or all; use all when the user needs both open and done threads. Optionally set onlyUnread to focus on unread items.
 - **list-channels**: Use to discover channels in a workspace. Requires a workspace ID. Optionally set includeArchived to true to also list archived channels. Returns channel names, IDs, descriptions, visibility, archive status, and URLs.
+- **send-direct-message**: Use when the user wants to send a private/direct message to a teammate (one or more users) — NOT in a channel. Pass the workspace ID, the recipient user IDs (do NOT include the sender), and the content. The tool finds the existing 1-on-1 or group conversation between those users or creates a new one.
+- **delete-item**: Use to permanently delete a thread, comment (thread reply), or message (conversation reply). Deletion is irreversible. The current user must be the author or a workspace admin. Use this for cleaning up posts that were sent in error.
 
 ### Best Practices:
 
@@ -81,6 +85,8 @@ function getMcpServer({ twistApiKey, baseUrl }: { twistApiKey: string; baseUrl?:
     registerTool(react, server, twist)
     registerTool(markDone, server, twist)
     registerTool(listChannels, server, twist)
+    registerTool(sendDirectMessage, server, twist)
+    registerTool(deleteItem, server, twist)
 
     return server
 }

--- a/src/tools/__tests__/__snapshots__/delete-item.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/delete-item.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`delete-item tool should delete a thread 1`] = `
+"# Deleted
+
+**Type:** thread
+**ID:** 12345
+
+This action is permanent."
+`;

--- a/src/tools/__tests__/__snapshots__/send-direct-message.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/send-direct-message.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`send-direct-message tool should create a new DM conversation and post a message when none exists 1`] = `
+"# Direct Message Sent
+
+**Conversation ID:** 33333
+**Recipients (user IDs):** 44444
+**Conversation existed before:** No (new conversation)
+**Message ID:** 98765
+**Created:** 2024-01-01T00:00:00.000Z
+**URL:** https://twist.com/a/11111/msg/33333/m/98765
+
+## Content
+
+Hello there"
+`;

--- a/src/tools/__tests__/delete-item.test.ts
+++ b/src/tools/__tests__/delete-item.test.ts
@@ -1,0 +1,118 @@
+import type { TwistApi } from '@doist/twist-sdk'
+import { jest } from '@jest/globals'
+import { extractTextContent, TEST_IDS } from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { deleteItem } from '../delete-item.js'
+
+const mockTwistApi = {
+    threads: {
+        deleteThread: jest.fn(),
+    },
+    comments: {
+        deleteComment: jest.fn(),
+    },
+    conversationMessages: {
+        deleteMessage: jest.fn(),
+    },
+} as unknown as jest.Mocked<TwistApi>
+
+const { DELETE_ITEM } = ToolNames
+
+describe(`${DELETE_ITEM} tool`, () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('should delete a thread', async () => {
+        mockTwistApi.threads.deleteThread.mockResolvedValue(undefined)
+
+        const result = await deleteItem.execute(
+            { targetType: 'thread', targetId: TEST_IDS.THREAD_1 },
+            mockTwistApi,
+        )
+
+        expect(mockTwistApi.threads.deleteThread).toHaveBeenCalledWith(TEST_IDS.THREAD_1)
+        expect(mockTwistApi.comments.deleteComment).not.toHaveBeenCalled()
+        expect(mockTwistApi.conversationMessages.deleteMessage).not.toHaveBeenCalled()
+
+        expect(extractTextContent(result)).toMatchSnapshot()
+        expect(result.structuredContent).toEqual({
+            type: 'delete_item_result',
+            success: true,
+            targetType: 'thread',
+            targetId: TEST_IDS.THREAD_1,
+        })
+    })
+
+    it('should delete a comment', async () => {
+        mockTwistApi.comments.deleteComment.mockResolvedValue(undefined)
+
+        const result = await deleteItem.execute(
+            { targetType: 'comment', targetId: TEST_IDS.COMMENT_1 },
+            mockTwistApi,
+        )
+
+        expect(mockTwistApi.comments.deleteComment).toHaveBeenCalledWith(TEST_IDS.COMMENT_1)
+        expect(mockTwistApi.threads.deleteThread).not.toHaveBeenCalled()
+        expect(mockTwistApi.conversationMessages.deleteMessage).not.toHaveBeenCalled()
+
+        expect(result.structuredContent).toEqual({
+            type: 'delete_item_result',
+            success: true,
+            targetType: 'comment',
+            targetId: TEST_IDS.COMMENT_1,
+        })
+    })
+
+    it('should delete a conversation message', async () => {
+        mockTwistApi.conversationMessages.deleteMessage.mockResolvedValue(undefined)
+
+        const result = await deleteItem.execute(
+            { targetType: 'message', targetId: TEST_IDS.MESSAGE_1 },
+            mockTwistApi,
+        )
+
+        expect(mockTwistApi.conversationMessages.deleteMessage).toHaveBeenCalledWith(
+            TEST_IDS.MESSAGE_1,
+        )
+        expect(mockTwistApi.threads.deleteThread).not.toHaveBeenCalled()
+        expect(mockTwistApi.comments.deleteComment).not.toHaveBeenCalled()
+
+        expect(result.structuredContent).toEqual({
+            type: 'delete_item_result',
+            success: true,
+            targetType: 'message',
+            targetId: TEST_IDS.MESSAGE_1,
+        })
+    })
+
+    it('should propagate thread delete errors', async () => {
+        mockTwistApi.threads.deleteThread.mockRejectedValue(new Error('Forbidden'))
+
+        await expect(
+            deleteItem.execute({ targetType: 'thread', targetId: TEST_IDS.THREAD_1 }, mockTwistApi),
+        ).rejects.toThrow('Forbidden')
+    })
+
+    it('should propagate comment delete errors', async () => {
+        mockTwistApi.comments.deleteComment.mockRejectedValue(new Error('Not found'))
+
+        await expect(
+            deleteItem.execute(
+                { targetType: 'comment', targetId: TEST_IDS.COMMENT_1 },
+                mockTwistApi,
+            ),
+        ).rejects.toThrow('Not found')
+    })
+
+    it('should propagate message delete errors', async () => {
+        mockTwistApi.conversationMessages.deleteMessage.mockRejectedValue(new Error('Forbidden'))
+
+        await expect(
+            deleteItem.execute(
+                { targetType: 'message', targetId: TEST_IDS.MESSAGE_1 },
+                mockTwistApi,
+            ),
+        ).rejects.toThrow('Forbidden')
+    })
+})

--- a/src/tools/__tests__/send-direct-message.test.ts
+++ b/src/tools/__tests__/send-direct-message.test.ts
@@ -1,0 +1,159 @@
+import type { TwistApi } from '@doist/twist-sdk'
+import { jest } from '@jest/globals'
+import {
+    createMockConversation,
+    createMockConversationMessage,
+    extractTextContent,
+    TEST_IDS,
+} from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { sendDirectMessage } from '../send-direct-message.js'
+
+const mockTwistApi = {
+    conversations: {
+        getOrCreateConversation: jest.fn(),
+    },
+    conversationMessages: {
+        createMessage: jest.fn(),
+    },
+} as unknown as jest.Mocked<TwistApi>
+
+const { SEND_DIRECT_MESSAGE } = ToolNames
+
+describe(`${SEND_DIRECT_MESSAGE} tool`, () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('should create a new DM conversation and post a message when none exists', async () => {
+        const mockConversation = createMockConversation({
+            userIds: [TEST_IDS.USER_1, TEST_IDS.USER_2],
+            messageCount: 0,
+        })
+        const mockMessage = createMockConversationMessage()
+
+        mockTwistApi.conversations.getOrCreateConversation.mockResolvedValue(mockConversation)
+        mockTwistApi.conversationMessages.createMessage.mockResolvedValue(mockMessage)
+
+        const result = await sendDirectMessage.execute(
+            {
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                userIds: [TEST_IDS.USER_2],
+                content: 'Hello there',
+            },
+            mockTwistApi,
+        )
+
+        expect(mockTwistApi.conversations.getOrCreateConversation).toHaveBeenCalledWith({
+            workspaceId: TEST_IDS.WORKSPACE_1,
+            userIds: [TEST_IDS.USER_2],
+        })
+        expect(mockTwistApi.conversationMessages.createMessage).toHaveBeenCalledWith({
+            conversationId: mockConversation.id,
+            content: 'Hello there',
+        })
+
+        expect(extractTextContent(result)).toMatchSnapshot()
+
+        const { structuredContent } = result
+        expect(structuredContent).toEqual(
+            expect.objectContaining({
+                type: 'send_direct_message_result',
+                success: true,
+                conversationId: mockConversation.id,
+                workspaceId: mockConversation.workspaceId,
+                userIds: mockConversation.userIds,
+                messageId: mockMessage.id,
+                content: 'Hello there',
+                createdConversation: true,
+                conversationUrl: expect.stringContaining('twist.com'),
+                messageUrl: expect.stringContaining('twist.com'),
+            }),
+        )
+    })
+
+    it('should reuse an existing conversation and flag it as not newly created', async () => {
+        const mockConversation = createMockConversation({
+            userIds: [TEST_IDS.USER_1, TEST_IDS.USER_2],
+            messageCount: 12,
+        })
+        const mockMessage = createMockConversationMessage()
+
+        mockTwistApi.conversations.getOrCreateConversation.mockResolvedValue(mockConversation)
+        mockTwistApi.conversationMessages.createMessage.mockResolvedValue(mockMessage)
+
+        const result = await sendDirectMessage.execute(
+            {
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                userIds: [TEST_IDS.USER_2],
+                content: 'Hello again',
+            },
+            mockTwistApi,
+        )
+
+        const { structuredContent } = result
+        expect(structuredContent?.createdConversation).toBe(false)
+    })
+
+    it('should support a group DM with multiple user IDs', async () => {
+        const mockConversation = createMockConversation({
+            userIds: [TEST_IDS.USER_1, TEST_IDS.USER_2, 99999],
+            messageCount: 0,
+        })
+        mockTwistApi.conversations.getOrCreateConversation.mockResolvedValue(mockConversation)
+        mockTwistApi.conversationMessages.createMessage.mockResolvedValue(
+            createMockConversationMessage(),
+        )
+
+        await sendDirectMessage.execute(
+            {
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                userIds: [TEST_IDS.USER_2, 99999],
+                content: 'Group ping',
+            },
+            mockTwistApi,
+        )
+
+        expect(mockTwistApi.conversations.getOrCreateConversation).toHaveBeenCalledWith({
+            workspaceId: TEST_IDS.WORKSPACE_1,
+            userIds: [TEST_IDS.USER_2, 99999],
+        })
+    })
+
+    it('should propagate getOrCreateConversation errors', async () => {
+        mockTwistApi.conversations.getOrCreateConversation.mockRejectedValue(
+            new Error('Workspace not found'),
+        )
+
+        await expect(
+            sendDirectMessage.execute(
+                {
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                    userIds: [TEST_IDS.USER_2],
+                    content: 'Hi',
+                },
+                mockTwistApi,
+            ),
+        ).rejects.toThrow('Workspace not found')
+
+        expect(mockTwistApi.conversationMessages.createMessage).not.toHaveBeenCalled()
+    })
+
+    it('should propagate createMessage errors after the conversation exists', async () => {
+        mockTwistApi.conversations.getOrCreateConversation.mockResolvedValue(
+            createMockConversation(),
+        )
+        mockTwistApi.conversationMessages.createMessage.mockRejectedValue(new Error('Rate limited'))
+
+        await expect(
+            sendDirectMessage.execute(
+                {
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                    userIds: [TEST_IDS.USER_2],
+                    content: 'Hi',
+                },
+                mockTwistApi,
+            ),
+        ).rejects.toThrow('Rate limited')
+    })
+})

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -124,6 +124,20 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         destructiveHint: false,
         idempotentHint: true,
     },
+    {
+        name: ToolNames.SEND_DIRECT_MESSAGE,
+        title: 'Twist: Send Direct Message',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+    },
+    {
+        name: ToolNames.DELETE_ITEM,
+        title: 'Twist: Delete Item',
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+    },
 ]
 
 describe('Tool annotations', () => {

--- a/src/tools/delete-item.ts
+++ b/src/tools/delete-item.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TwistTool } from '../twist-tool.js'
+import { type DeleteItemOutput, DeleteItemOutputSchema } from '../utils/output-schemas.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const TargetTypeSchema = z.enum(['thread', 'comment', 'message'])
+
+const ArgsSchema = {
+    targetType: TargetTypeSchema.describe(
+        'What to delete: a thread, a comment (reply on a thread), or a message (reply in a conversation/DM).',
+    ),
+    targetId: z.number().describe('The ID of the thread, comment, or message to delete.'),
+}
+
+const deleteItem = {
+    name: ToolNames.DELETE_ITEM,
+    description:
+        'Permanently delete a thread, comment, or conversation message. Deletion is irreversible — only the author or a workspace admin can delete an item. Use this to clean up posts that were sent in error or are no longer needed.',
+    parameters: ArgsSchema,
+    outputSchema: DeleteItemOutputSchema.shape,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
+    async execute(args, client) {
+        const { targetType, targetId } = args
+
+        if (targetType === 'thread') {
+            await client.threads.deleteThread(targetId)
+        } else if (targetType === 'comment') {
+            await client.comments.deleteComment(targetId)
+        } else {
+            await client.conversationMessages.deleteMessage(targetId)
+        }
+
+        const lines: string[] = [
+            `# Deleted`,
+            '',
+            `**Type:** ${targetType}`,
+            `**ID:** ${targetId}`,
+            '',
+            'This action is permanent.',
+        ]
+
+        const structuredContent: DeleteItemOutput = {
+            type: 'delete_item_result',
+            success: true,
+            targetType,
+            targetId,
+        }
+
+        return getToolOutput({
+            textContent: lines.join('\n'),
+            structuredContent,
+        })
+    },
+} satisfies TwistTool<typeof ArgsSchema, typeof DeleteItemOutputSchema.shape>
+
+export { deleteItem }

--- a/src/tools/send-direct-message.ts
+++ b/src/tools/send-direct-message.ts
@@ -1,0 +1,106 @@
+import { getFullTwistURL } from '@doist/twist-sdk'
+import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TwistTool } from '../twist-tool.js'
+import {
+    type SendDirectMessageOutput,
+    SendDirectMessageOutputSchema,
+} from '../utils/output-schemas.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    workspaceId: z.number().describe('The workspace ID to send the message in.'),
+    userIds: z
+        .array(z.number())
+        .min(1)
+        .describe(
+            'User IDs to message. One ID is a 1-on-1 DM; multiple IDs is a group conversation. Do NOT include the sender (current user) — Twist adds them automatically.',
+        ),
+    content: z.string().min(1).describe('The content of the message.'),
+}
+
+const sendDirectMessage = {
+    name: ToolNames.SEND_DIRECT_MESSAGE,
+    description:
+        'Send a direct (private) message to one or more workspace users. Finds the existing conversation between the given users (1-on-1 DM or group) or creates a new one, then posts the message. Use this instead of create-thread when the message is private and not meant for a channel.',
+    parameters: ArgsSchema,
+    outputSchema: SendDirectMessageOutputSchema.shape,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+    async execute(args, client) {
+        const { workspaceId, userIds, content } = args
+
+        const conversation = await client.conversations.getOrCreateConversation({
+            workspaceId,
+            userIds,
+        })
+
+        const message = await client.conversationMessages.createMessage({
+            conversationId: conversation.id,
+            content,
+        })
+
+        const conversationUrl =
+            conversation.url ??
+            getFullTwistURL({
+                workspaceId: conversation.workspaceId,
+                conversationId: conversation.id,
+            })
+
+        const messageUrl =
+            message.url ??
+            getFullTwistURL({
+                workspaceId: message.workspaceId,
+                conversationId: message.conversationId,
+                messageId: message.id,
+            })
+
+        const postedValue = message.posted
+        const created = postedValue
+            ? typeof postedValue === 'string'
+                ? new Date(postedValue)
+                : postedValue
+            : new Date()
+
+        // Heuristic: a brand-new conversation has 0 or 1 prior messages (the
+        // one we just sent). Anything more means it already existed.
+        const wasNew = (conversation.messageCount ?? 0) <= 1
+
+        const lines: string[] = [
+            `# Direct Message Sent`,
+            '',
+            `**Conversation ID:** ${conversation.id}`,
+            ...(conversation.title ? [`**Title:** ${conversation.title}`] : []),
+            `**Recipients (user IDs):** ${userIds.join(', ')}`,
+            `**Conversation existed before:** ${wasNew ? 'No (new conversation)' : 'Yes'}`,
+            `**Message ID:** ${message.id}`,
+            `**Created:** ${created.toISOString()}`,
+            `**URL:** ${messageUrl}`,
+            '',
+            '## Content',
+            '',
+            content,
+        ]
+
+        const structuredContent: SendDirectMessageOutput = {
+            type: 'send_direct_message_result',
+            success: true,
+            conversationId: conversation.id,
+            workspaceId: conversation.workspaceId,
+            userIds: conversation.userIds,
+            conversationTitle: conversation.title ?? undefined,
+            conversationUrl,
+            messageId: message.id,
+            content,
+            created: created.toISOString(),
+            messageUrl,
+            createdConversation: wasNew,
+        }
+
+        return getToolOutput({
+            textContent: lines.join('\n'),
+            structuredContent,
+        })
+    },
+} satisfies TwistTool<typeof ArgsSchema, typeof SendDirectMessageOutputSchema.shape>
+
+export { sendDirectMessage }

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -392,6 +392,34 @@ export const ListChannelsOutputSchema = z.object({
 })
 
 /**
+ * Schema for send-direct-message tool output
+ */
+export const SendDirectMessageOutputSchema = z.object({
+    type: z.literal('send_direct_message_result'),
+    success: z.boolean(),
+    conversationId: z.number(),
+    workspaceId: z.number(),
+    userIds: z.array(z.number()),
+    conversationTitle: z.string().optional(),
+    conversationUrl: z.string(),
+    messageId: z.number(),
+    content: z.string(),
+    created: z.string(),
+    messageUrl: z.string(),
+    createdConversation: z.boolean(),
+})
+
+/**
+ * Schema for delete-item tool output
+ */
+export const DeleteItemOutputSchema = z.object({
+    type: z.literal('delete_item_result'),
+    success: z.boolean(),
+    targetType: z.enum(['thread', 'comment', 'message']),
+    targetId: z.number(),
+})
+
+/**
  * Union of all possible structured outputs for type safety
  */
 export const StructuredOutputSchema = z.union([
@@ -411,6 +439,8 @@ export const StructuredOutputSchema = z.union([
     ReactOutputSchema,
     MarkDoneOutputSchema,
     ListChannelsOutputSchema,
+    SendDirectMessageOutputSchema,
+    DeleteItemOutputSchema,
 ])
 
 /**
@@ -432,4 +462,6 @@ export type ReplyOutput = z.infer<typeof ReplyOutputSchema>
 export type ReactOutput = z.infer<typeof ReactOutputSchema>
 export type MarkDoneOutput = z.infer<typeof MarkDoneOutputSchema>
 export type ListChannelsOutput = z.infer<typeof ListChannelsOutputSchema>
+export type SendDirectMessageOutput = z.infer<typeof SendDirectMessageOutputSchema>
+export type DeleteItemOutput = z.infer<typeof DeleteItemOutputSchema>
 export type StructuredOutput = z.infer<typeof StructuredOutputSchema>

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -15,4 +15,6 @@ export const ToolNames = {
     GET_USERS: 'get-users',
     AWAY: 'away',
     LIST_CHANNELS: 'list-channels',
+    SEND_DIRECT_MESSAGE: 'send-direct-message',
+    DELETE_ITEM: 'delete-item',
 } as const


### PR DESCRIPTION
## Summary

Adds two new tools that fill gaps in the current toolset:

- **`send-direct-message`** — send a private DM to one or more workspace users. The current `reply` tool can post to a conversation if you already have the ID, but there is no tool that exposes a conversation ID for an arbitrary user — `fetch-inbox` only lists conversations with unread activity. This tool wraps `conversations.getOrCreateConversation` + `conversationMessages.createMessage` so an LLM can simply say "DM these users" without round-tripping through inbox lookups.
- **`delete-item`** — permanently delete a thread, comment, or conversation message. Useful for cleaning up posts sent in error. Uses a unified `targetType` parameter (`thread` / `comment` / `message`), matching the pattern already used by `reply` and `react`.

Both tools surfaced when an LLM client (Claude Code via MCP) tried to send a private heads-up to a teammate after a workflow event and discovered there was no route to a 1-on-1 DM, then needed to clean up after posting in the wrong channel.

## Implementation

Follows the existing add-a-tool checklist from `AGENTS.md`:

- [x] `src/utils/tool-names.ts` — added `SEND_DIRECT_MESSAGE` and `DELETE_ITEM` constants
- [x] `src/utils/output-schemas.ts` — added `SendDirectMessageOutputSchema`, `DeleteItemOutputSchema`, types, and union entries
- [x] `src/tools/send-direct-message.ts` and `src/tools/delete-item.ts`
- [x] `src/mcp-server.ts` — imports, `registerTool` calls, and tool usage guidelines added to the LLM `instructions` block
- [x] `src/index.ts` — imports, `tools` object, and named exports
- [x] `scripts/run-tool.ts` — imports and `tools` record entries
- [x] `src/tools/__tests__/tool-annotations.test.ts` — annotation expectations for both tools
- [x] `src/tools/__tests__/send-direct-message.test.ts` — new (5 tests, 1 snapshot)
- [x] `src/tools/__tests__/delete-item.test.ts` — new (6 tests, 1 snapshot)

## Annotations

- `send-direct-message`: `readOnlyHint: false`, `destructiveHint: false`, `idempotentHint: false`
- `delete-item`: `readOnlyHint: false`, `destructiveHint: true`, `idempotentHint: false`

## Notes

The `send-direct-message` tool's `createdConversation` flag uses a heuristic — `messageCount <= 1` after the call means the conversation was just created (only the message we just posted exists). The Twist API doesn't surface a "newly created" indicator on `getOrCreateConversation`, so this is the cleanest signal available.

## Test plan

- [x] `npm test` — 172/172 passing (was 161 before)
- [x] `npm run build` — clean
- [x] `npm run format:check` — clean
- [x] Smoke-tested both tools live against a real workspace via `scripts/run-tool.ts`:
  - `send-direct-message` created a conversation and posted to it
  - `delete-item` deleted a thread, then a second thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)