### PR TITLE
feat: add update-message tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { react } from './tools/react.js'
 import { reply } from './tools/reply.js'
 import { searchContent } from './tools/search-content.js'
 import { updateComment } from './tools/update-comment.js'
+import { updateMessage } from './tools/update-message.js'
 import { updateThread } from './tools/update-thread.js'
 import { userInfo } from './tools/user-info.js'
 
@@ -24,6 +25,7 @@ const tools = {
     createThread,
     updateThread,
     updateComment,
+    updateMessage,
     reply,
     react,
     markDone,
@@ -43,6 +45,7 @@ export {
     createThread,
     updateThread,
     updateComment,
+    updateMessage,
     reply,
     react,
     markDone,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -15,6 +15,7 @@ import { react } from './tools/react.js'
 import { reply } from './tools/reply.js'
 import { searchContent } from './tools/search-content.js'
 import { updateComment } from './tools/update-comment.js'
+import { updateMessage } from './tools/update-message.js'
 import { updateThread } from './tools/update-thread.js'
 import { userInfo } from './tools/user-info.js'
 
@@ -33,6 +34,7 @@ You have access to comprehensive Twist management tools for team communication a
 
 - **fetch-inbox**: Use to fetch inbox threads for a workspace, along with unread conversations and counts. Supports archiveFilter values of active, archived, or all; use all when the user needs both open and done threads. Optionally set onlyUnread to focus on unread items.
 - **list-channels**: Use to discover channels in a workspace. Requires a workspace ID. Optionally set includeArchived to true to also list archived channels. Returns channel names, IDs, descriptions, visibility, archive status, and URLs.
+- **update-message**: Use to edit a conversation (DM) message you previously sent. Pass the message ID and the new content. For thread comments use update-comment; for thread bodies use update-thread.
 
 ### Best Practices:
 
@@ -77,6 +79,7 @@ function getMcpServer({ twistApiKey, baseUrl }: { twistApiKey: string; baseUrl?:
     registerTool(createThread, server, twist)
     registerTool(updateThread, server, twist)
     registerTool(updateComment, server, twist)
+    registerTool(updateMessage, server, twist)
     registerTool(reply, server, twist)
     registerTool(react, server, twist)
     registerTool(markDone, server, twist)

--- a/src/tools/__tests__/__snapshots__/update-message.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/update-message.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`update-message tool updating messages should update a conversation message content 1`] = `
+"# Message Updated
+
+**Message ID:** 98765
+**Conversation ID:** 33333
+**Workspace ID:** 11111
+**Last Edited:** 2025-02-03T12:34:56.000Z
+**URL:** https://twist.com/a/11111/msg/33333/m/98765
+
+## Content
+
+Updated message content"
+`;

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -97,6 +97,13 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         idempotentHint: true,
     },
     {
+        name: ToolNames.UPDATE_MESSAGE,
+        title: 'Twist: Update Message',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    {
         name: ToolNames.REPLY,
         title: 'Twist: Reply',
         readOnlyHint: false,

--- a/src/tools/__tests__/update-message.test.ts
+++ b/src/tools/__tests__/update-message.test.ts
@@ -1,0 +1,104 @@
+import type { TwistApi } from '@doist/twist-sdk'
+import { jest } from '@jest/globals'
+import {
+    createMockConversationMessage,
+    extractTextContent,
+    TEST_IDS,
+} from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { updateMessage } from '../update-message.js'
+
+const mockTwistApi = {
+    conversationMessages: {
+        updateMessage: jest.fn(),
+    },
+} as unknown as jest.Mocked<TwistApi>
+
+const { UPDATE_MESSAGE } = ToolNames
+
+describe(`${UPDATE_MESSAGE} tool`, () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('updating messages', () => {
+        it('should update a conversation message content', async () => {
+            const mockMessage = createMockConversationMessage({
+                content: 'Updated message content',
+                lastEdited: new Date('2025-02-03T12:34:56Z'),
+            })
+            mockTwistApi.conversationMessages.updateMessage.mockResolvedValue(mockMessage)
+
+            const result = await updateMessage.execute(
+                {
+                    id: TEST_IDS.MESSAGE_1,
+                    content: 'Updated message content',
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.conversationMessages.updateMessage).toHaveBeenCalledWith({
+                id: TEST_IDS.MESSAGE_1,
+                content: 'Updated message content',
+            })
+
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    type: 'update_message_result',
+                    success: true,
+                    messageId: mockMessage.id,
+                    conversationId: mockMessage.conversationId,
+                    workspaceId: mockMessage.workspaceId,
+                    content: 'Updated message content',
+                    messageUrl: expect.stringContaining('twist.com'),
+                    lastEdited: '2025-02-03T12:34:56.000Z',
+                }),
+            )
+        })
+
+        it('should omit lastEdited when not returned by the API', async () => {
+            const mockMessage = createMockConversationMessage({
+                content: 'Edited again',
+                lastEdited: null,
+            })
+            mockTwistApi.conversationMessages.updateMessage.mockResolvedValue(mockMessage)
+
+            const result = await updateMessage.execute(
+                {
+                    id: TEST_IDS.MESSAGE_1,
+                    content: 'Edited again',
+                },
+                mockTwistApi,
+            )
+
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    type: 'update_message_result',
+                    success: true,
+                    lastEdited: undefined,
+                }),
+            )
+        })
+    })
+
+    describe('error handling', () => {
+        it('should propagate API errors', async () => {
+            const apiError = new Error('Message not found')
+            mockTwistApi.conversationMessages.updateMessage.mockRejectedValue(apiError)
+
+            await expect(
+                updateMessage.execute(
+                    {
+                        id: TEST_IDS.MESSAGE_1,
+                        content: 'Updated content',
+                    },
+                    mockTwistApi,
+                ),
+            ).rejects.toThrow('Message not found')
+        })
+    })
+})

--- a/src/tools/update-message.ts
+++ b/src/tools/update-message.ts
@@ -1,0 +1,70 @@
+import { getFullTwistURL } from '@doist/twist-sdk'
+import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TwistTool } from '../twist-tool.js'
+import { type UpdateMessageOutput, UpdateMessageOutputSchema } from '../utils/output-schemas.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    id: z.number().describe('The ID of the conversation message to update.'),
+    content: z.string().min(1).describe('The new content for the message.'),
+}
+
+const updateMessage = {
+    name: ToolNames.UPDATE_MESSAGE,
+    description:
+        "Update an existing conversation (DM) message's content. Requires the message ID and the new content. Use this to correct or revise a message you previously sent in a direct/group conversation. For thread comments use update-comment instead; for thread bodies use update-thread.",
+    parameters: ArgsSchema,
+    outputSchema: UpdateMessageOutputSchema.shape,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    async execute(args, client) {
+        const { id, content } = args
+
+        const message = await client.conversationMessages.updateMessage({
+            id,
+            content,
+        })
+
+        const messageUrl =
+            message.url ??
+            getFullTwistURL({
+                workspaceId: message.workspaceId,
+                conversationId: message.conversationId,
+                messageId: message.id,
+            })
+
+        const lastEdited = message.lastEdited ? message.lastEdited.toISOString() : undefined
+
+        const lines: string[] = [
+            `# Message Updated`,
+            '',
+            `**Message ID:** ${message.id}`,
+            `**Conversation ID:** ${message.conversationId}`,
+            `**Workspace ID:** ${message.workspaceId}`,
+            ...(lastEdited ? [`**Last Edited:** ${lastEdited}`] : []),
+            `**URL:** ${messageUrl}`,
+            '',
+            '## Content',
+            '',
+            message.content,
+        ]
+
+        const structuredContent: UpdateMessageOutput = {
+            type: 'update_message_result',
+            success: true,
+            messageId: message.id,
+            conversationId: message.conversationId,
+            workspaceId: message.workspaceId,
+            content: message.content,
+            messageUrl,
+            lastEdited,
+        }
+
+        return getToolOutput({
+            textContent: lines.join('\n'),
+            structuredContent,
+        })
+    },
+} satisfies TwistTool<typeof ArgsSchema, typeof UpdateMessageOutputSchema.shape>
+
+export { updateMessage }

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -312,6 +312,20 @@ export const UpdateCommentOutputSchema = z.object({
 })
 
 /**
+ * Schema for update-message tool output
+ */
+export const UpdateMessageOutputSchema = z.object({
+    type: z.literal('update_message_result'),
+    success: z.boolean(),
+    messageId: z.number(),
+    conversationId: z.number(),
+    workspaceId: z.number(),
+    content: z.string(),
+    messageUrl: z.string(),
+    lastEdited: z.string().nullable().optional(),
+})
+
+/**
  * Schema for reply tool output
  */
 export const ReplyOutputSchema = z.object({
@@ -407,6 +421,7 @@ export const StructuredOutputSchema = z.union([
     CreateThreadOutputSchema,
     UpdateThreadOutputSchema,
     UpdateCommentOutputSchema,
+    UpdateMessageOutputSchema,
     ReplyOutputSchema,
     ReactOutputSchema,
     MarkDoneOutputSchema,
@@ -419,6 +434,7 @@ export const StructuredOutputSchema = z.union([
 export type CreateThreadOutput = z.infer<typeof CreateThreadOutputSchema>
 export type UpdateThreadOutput = z.infer<typeof UpdateThreadOutputSchema>
 export type UpdateCommentOutput = z.infer<typeof UpdateCommentOutputSchema>
+export type UpdateMessageOutput = z.infer<typeof UpdateMessageOutputSchema>
 export type AwayOutput = z.infer<typeof AwayOutputSchema>
 export type LoadThreadOutput = z.infer<typeof LoadThreadOutputSchema>
 export type LoadConversationOutput = z.infer<typeof LoadConversationOutputSchema>

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -7,6 +7,7 @@ export const ToolNames = {
     CREATE_THREAD: 'create-thread',
     UPDATE_THREAD: 'update-thread',
     UPDATE_COMMENT: 'update-comment',
+    UPDATE_MESSAGE: 'update-message',
     REPLY: 'reply',
     REACT: 'react',
     MARK_DONE: 'mark-done',


### PR DESCRIPTION
## Summary

Adds a new `update-message` tool that edits an existing conversation (DM) message — fills the gap left by `update-thread` (covers thread bodies) and `update-comment` (covers thread comments). Without this, there's no way for an MCP client to correct a typo or revise a message it already sent in a 1-on-1 or group conversation, even though the underlying Twist API and `@doist/twist-sdk` (`client.conversationMessages.updateMessage`) both support it.

The tool wraps `client.conversationMessages.updateMessage({ id, content })` and returns the same shape used by `update-comment` (text + structured output, last-edited timestamp).

Annotations: `readOnlyHint: false`, `destructiveHint: false`, `idempotentHint: true` — same hint profile as `update-comment` and `update-thread`.

## Test plan

- [x] `npm run type-check` clean
- [x] `npm run format:check` clean
- [x] `npm test` — 162/162 passing, snapshot test added for the formatted text output
- [x] `npm run build` succeeds, `dist/tools/update-message.js` produced
- [x] New tests cover happy path, missing `lastEdited`, and API error propagation
- [x] `tool-annotations.test.ts` updated so the registry-coverage assertion stays in sync