### PR TITLE
feat: add delete-object tool

### DIFF
--- a/scripts/run-tool.ts
+++ b/scripts/run-tool.ts
@@ -20,6 +20,7 @@ import { config } from 'dotenv'
 import { away } from '../src/tools/away.js'
 import { buildLink } from '../src/tools/build-link.js'
 import { createThread } from '../src/tools/create-thread.js'
+import { deleteObject } from '../src/tools/delete-object.js'
 import { fetchInbox } from '../src/tools/fetch-inbox.js'
 import { getGroups } from '../src/tools/get-groups.js'
 import { getMentions } from '../src/tools/get-mentions.js'
@@ -58,6 +59,7 @@ const tools: Record<string, ExecutableTool> = {
     'get-mentions': getMentions,
     'create-thread': createThread,
     'update-object': updateObject,
+    'delete-object': deleteObject,
     reply: reply,
     react: react,
     'mark-done': markDone,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { getMcpServer } from './mcp-server.js'
 import { away } from './tools/away.js'
 import { buildLink } from './tools/build-link.js'
 import { createThread } from './tools/create-thread.js'
+import { deleteObject } from './tools/delete-object.js'
 import { fetchInbox } from './tools/fetch-inbox.js'
 import { getGroups } from './tools/get-groups.js'
 import { getMentions } from './tools/get-mentions.js'
@@ -25,6 +26,7 @@ const tools = {
     getMentions,
     createThread,
     updateObject,
+    deleteObject,
     reply,
     react,
     markDone,
@@ -45,6 +47,7 @@ export {
     getMentions,
     createThread,
     updateObject,
+    deleteObject,
     reply,
     react,
     markDone,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -40,7 +40,7 @@ You have access to comprehensive Twist management tools for team communication a
 - **reply**: Use to reply to a thread or conversation. Thread replies notify everyone who has interacted with the thread by default. Optionally pass recipients for user IDs or groups for group IDs to override that default, and/or notifyAudience ("channel" | "thread") to add a broader audience on top of recipients/groups. Passing groups or notifyAudience to a conversation reply is rejected.
 - **get-mentions**: Use to fetch threads, comments, and messages that mention the current user. Prefer this over search-content when no keyword query is needed (search-content requires a non-empty query). Supports filtering by channel, author, and date range, and exposes a cursor for pagination.
 - **update-object**: Use to edit something you previously sent. Pass targetType ("thread", "comment", or "message"), targetId, and the new content. For threads you may also pass title (and may pass title without content). title is only valid for threads.
-- **delete-object**: Use to permanently delete a thread, comment, or conversation message. Pass targetType ("thread", "comment", or "message") and targetId. Deletion is irreversible — confirm with the user before invoking. Deleting a thread also removes all of its comments.
+- **delete-object**: Use to permanently delete a thread, comment, or conversation message. Pass targetType ("thread", "comment", or "message") and targetId. Deletion is irreversible — confirm with the user before invoking. Deleting a thread also removes all of its comments. Only the object's creator or a workspace admin can delete; the Twist API will reject the call otherwise.
 
 ### Best Practices:
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -4,6 +4,7 @@ import { registerTool } from './mcp-helpers.js'
 import { away } from './tools/away.js'
 import { buildLink } from './tools/build-link.js'
 import { createThread } from './tools/create-thread.js'
+import { deleteObject } from './tools/delete-object.js'
 import { fetchInbox } from './tools/fetch-inbox.js'
 import { getGroups } from './tools/get-groups.js'
 import { getMentions } from './tools/get-mentions.js'
@@ -39,6 +40,7 @@ You have access to comprehensive Twist management tools for team communication a
 - **reply**: Use to reply to a thread or conversation. Thread replies notify everyone who has interacted with the thread by default. Optionally pass recipients for user IDs or groups for group IDs to override that default, and/or notifyAudience ("channel" | "thread") to add a broader audience on top of recipients/groups. Passing groups or notifyAudience to a conversation reply is rejected.
 - **get-mentions**: Use to fetch threads, comments, and messages that mention the current user. Prefer this over search-content when no keyword query is needed (search-content requires a non-empty query). Supports filtering by channel, author, and date range, and exposes a cursor for pagination.
 - **update-object**: Use to edit something you previously sent. Pass targetType ("thread", "comment", or "message"), targetId, and the new content. For threads you may also pass title (and may pass title without content). title is only valid for threads.
+- **delete-object**: Use to permanently delete a thread, comment, or conversation message. Pass targetType ("thread", "comment", or "message") and targetId. Deletion is irreversible — confirm with the user before invoking. Deleting a thread also removes all of its comments.
 
 ### Best Practices:
 
@@ -84,6 +86,7 @@ function getMcpServer({ twistApiKey, baseUrl }: { twistApiKey: string; baseUrl?:
     registerTool(buildLink, server, twist)
     registerTool(createThread, server, twist)
     registerTool(updateObject, server, twist)
+    registerTool(deleteObject, server, twist)
     registerTool(reply, server, twist)
     registerTool(react, server, twist)
     registerTool(markDone, server, twist)

--- a/src/tools/__tests__/__snapshots__/delete-object.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/delete-object.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`delete-object tool targetType: comment should delete a comment by ID 1`] = `
+"# Comment Deleted
+
+**Comment ID:** 54321
+
+The comment has been permanently deleted."
+`;
+
+exports[`delete-object tool targetType: message should delete a conversation message by ID 1`] = `
+"# Message Deleted
+
+**Message ID:** 98765
+
+The conversation message has been permanently deleted."
+`;
+
+exports[`delete-object tool targetType: thread should delete a thread by ID 1`] = `
+"# Thread Deleted
+
+**Thread ID:** 12345
+
+The thread has been permanently deleted."
+`;

--- a/src/tools/__tests__/delete-object.test.ts
+++ b/src/tools/__tests__/delete-object.test.ts
@@ -1,0 +1,175 @@
+import type { TwistApi } from '@doist/twist-sdk'
+import { jest } from '@jest/globals'
+import { extractTextContent, TEST_IDS } from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { deleteObject } from '../delete-object.js'
+
+const mockTwistApi = {
+    threads: {
+        deleteThread: jest.fn(),
+    },
+    comments: {
+        deleteComment: jest.fn(),
+    },
+    conversationMessages: {
+        deleteMessage: jest.fn(),
+    },
+} as unknown as jest.Mocked<TwistApi>
+
+const { DELETE_OBJECT } = ToolNames
+
+describe(`${DELETE_OBJECT} tool`, () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('targetType: thread', () => {
+        it('should delete a thread by ID', async () => {
+            ;(mockTwistApi.threads.deleteThread as jest.Mock).mockResolvedValue(undefined as never)
+
+            const result = await deleteObject.execute(
+                {
+                    targetType: 'thread',
+                    targetId: TEST_IDS.THREAD_1,
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.threads.deleteThread).toHaveBeenCalledWith(TEST_IDS.THREAD_1)
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            const { structuredContent } = result
+            expect(structuredContent).toEqual({
+                type: 'delete_thread_result',
+                success: true,
+                targetType: 'thread',
+                threadId: TEST_IDS.THREAD_1,
+            })
+        })
+
+        it('should propagate API errors when deleting a thread', async () => {
+            ;(mockTwistApi.threads.deleteThread as jest.Mock).mockRejectedValue(
+                new Error('Thread not found') as never,
+            )
+
+            await expect(
+                deleteObject.execute(
+                    {
+                        targetType: 'thread',
+                        targetId: TEST_IDS.THREAD_1,
+                    },
+                    mockTwistApi,
+                ),
+            ).rejects.toThrow('Thread not found')
+        })
+    })
+
+    describe('targetType: comment', () => {
+        it('should delete a comment by ID', async () => {
+            ;(mockTwistApi.comments.deleteComment as jest.Mock).mockResolvedValue(
+                undefined as never,
+            )
+
+            const result = await deleteObject.execute(
+                {
+                    targetType: 'comment',
+                    targetId: TEST_IDS.COMMENT_1,
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.comments.deleteComment).toHaveBeenCalledWith(TEST_IDS.COMMENT_1)
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            const { structuredContent } = result
+            expect(structuredContent).toEqual({
+                type: 'delete_comment_result',
+                success: true,
+                targetType: 'comment',
+                commentId: TEST_IDS.COMMENT_1,
+            })
+        })
+
+        it('should propagate API errors when deleting a comment', async () => {
+            ;(mockTwistApi.comments.deleteComment as jest.Mock).mockRejectedValue(
+                new Error('Comment not found') as never,
+            )
+
+            await expect(
+                deleteObject.execute(
+                    {
+                        targetType: 'comment',
+                        targetId: TEST_IDS.COMMENT_1,
+                    },
+                    mockTwistApi,
+                ),
+            ).rejects.toThrow('Comment not found')
+        })
+    })
+
+    describe('targetType: message', () => {
+        it('should delete a conversation message by ID', async () => {
+            ;(mockTwistApi.conversationMessages.deleteMessage as jest.Mock).mockResolvedValue(
+                undefined as never,
+            )
+
+            const result = await deleteObject.execute(
+                {
+                    targetType: 'message',
+                    targetId: TEST_IDS.MESSAGE_1,
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.conversationMessages.deleteMessage).toHaveBeenCalledWith(
+                TEST_IDS.MESSAGE_1,
+            )
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            const { structuredContent } = result
+            expect(structuredContent).toEqual({
+                type: 'delete_message_result',
+                success: true,
+                targetType: 'message',
+                messageId: TEST_IDS.MESSAGE_1,
+            })
+        })
+
+        it('should propagate API errors when deleting a message', async () => {
+            ;(mockTwistApi.conversationMessages.deleteMessage as jest.Mock).mockRejectedValue(
+                new Error('Message not found') as never,
+            )
+
+            await expect(
+                deleteObject.execute(
+                    {
+                        targetType: 'message',
+                        targetId: TEST_IDS.MESSAGE_1,
+                    },
+                    mockTwistApi,
+                ),
+            ).rejects.toThrow('Message not found')
+        })
+    })
+
+    describe('routing', () => {
+        it('should only call the matching SDK method for each targetType', async () => {
+            ;(mockTwistApi.threads.deleteThread as jest.Mock).mockResolvedValue(undefined as never)
+            ;(mockTwistApi.comments.deleteComment as jest.Mock).mockResolvedValue(
+                undefined as never,
+            )
+            ;(mockTwistApi.conversationMessages.deleteMessage as jest.Mock).mockResolvedValue(
+                undefined as never,
+            )
+
+            await deleteObject.execute(
+                { targetType: 'thread', targetId: TEST_IDS.THREAD_1 },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.threads.deleteThread).toHaveBeenCalledTimes(1)
+            expect(mockTwistApi.comments.deleteComment).not.toHaveBeenCalled()
+            expect(mockTwistApi.conversationMessages.deleteMessage).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/src/tools/__tests__/delete-object.test.ts
+++ b/src/tools/__tests__/delete-object.test.ts
@@ -153,23 +153,49 @@ describe(`${DELETE_OBJECT} tool`, () => {
     })
 
     describe('routing', () => {
-        it('should only call the matching SDK method for each targetType', async () => {
-            ;(mockTwistApi.threads.deleteThread as jest.Mock).mockResolvedValue(undefined as never)
-            ;(mockTwistApi.comments.deleteComment as jest.Mock).mockResolvedValue(
-                undefined as never,
-            )
-            ;(mockTwistApi.conversationMessages.deleteMessage as jest.Mock).mockResolvedValue(
-                undefined as never,
-            )
+        const routingCases = [
+            {
+                targetType: 'thread' as const,
+                targetId: TEST_IDS.THREAD_1,
+                expectedMethod: 'threads.deleteThread',
+            },
+            {
+                targetType: 'comment' as const,
+                targetId: TEST_IDS.COMMENT_1,
+                expectedMethod: 'comments.deleteComment',
+            },
+            {
+                targetType: 'message' as const,
+                targetId: TEST_IDS.MESSAGE_1,
+                expectedMethod: 'conversationMessages.deleteMessage',
+            },
+        ]
 
-            await deleteObject.execute(
-                { targetType: 'thread', targetId: TEST_IDS.THREAD_1 },
-                mockTwistApi,
-            )
+        it.each(routingCases)(
+            'should only call $expectedMethod when targetType is $targetType',
+            async ({ targetType, targetId }) => {
+                ;(mockTwistApi.threads.deleteThread as jest.Mock).mockResolvedValue(
+                    undefined as never,
+                )
+                ;(mockTwistApi.comments.deleteComment as jest.Mock).mockResolvedValue(
+                    undefined as never,
+                )
+                ;(mockTwistApi.conversationMessages.deleteMessage as jest.Mock).mockResolvedValue(
+                    undefined as never,
+                )
 
-            expect(mockTwistApi.threads.deleteThread).toHaveBeenCalledTimes(1)
-            expect(mockTwistApi.comments.deleteComment).not.toHaveBeenCalled()
-            expect(mockTwistApi.conversationMessages.deleteMessage).not.toHaveBeenCalled()
-        })
+                await deleteObject.execute({ targetType, targetId }, mockTwistApi)
+
+                expect(mockTwistApi.threads.deleteThread).toHaveBeenCalledTimes(
+                    targetType === 'thread' ? 1 : 0,
+                )
+                expect(mockTwistApi.comments.deleteComment).toHaveBeenCalledTimes(
+                    targetType === 'comment' ? 1 : 0,
+                )
+                expect(mockTwistApi.conversationMessages.deleteMessage).toHaveBeenCalledTimes(
+                    targetType === 'message' ? 1 : 0,
+                )
+            },
+        )
     })
 })

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -104,6 +104,13 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         idempotentHint: true,
     },
     {
+        name: ToolNames.DELETE_OBJECT,
+        title: 'Twist: Delete Object',
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+    },
+    {
         name: ToolNames.REPLY,
         title: 'Twist: Reply',
         readOnlyHint: false,

--- a/src/tools/delete-object.ts
+++ b/src/tools/delete-object.ts
@@ -1,0 +1,120 @@
+import type { TwistApi } from '@doist/twist-sdk'
+import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TwistTool } from '../twist-tool.js'
+import {
+    type DeleteCommentOutput,
+    type DeleteMessageOutput,
+    DeleteObjectOutputSchema,
+    type DeleteObjectStructured,
+    type DeleteThreadOutput,
+} from '../utils/output-schemas.js'
+import { DeleteTargetTypeSchema } from '../utils/target-types.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    targetType: DeleteTargetTypeSchema.describe(
+        'The type of object to delete: thread, comment, or message.',
+    ),
+    targetId: z
+        .number()
+        .describe('The ID of the thread, comment, or conversation message to delete.'),
+}
+
+type Args = z.infer<z.ZodObject<typeof ArgsSchema>>
+type Branch = { textContent: string; structuredContent: DeleteObjectStructured }
+
+async function deleteThreadBranch(args: Args, client: TwistApi): Promise<Branch> {
+    const { targetId } = args
+
+    await client.threads.deleteThread(targetId)
+
+    const lines: string[] = [
+        `# Thread Deleted`,
+        '',
+        `**Thread ID:** ${targetId}`,
+        '',
+        'The thread has been permanently deleted.',
+    ]
+
+    const structuredContent: DeleteThreadOutput = {
+        type: 'delete_thread_result',
+        success: true,
+        targetType: 'thread',
+        threadId: targetId,
+    }
+
+    return { textContent: lines.join('\n'), structuredContent }
+}
+
+async function deleteCommentBranch(args: Args, client: TwistApi): Promise<Branch> {
+    const { targetId } = args
+
+    await client.comments.deleteComment(targetId)
+
+    const lines: string[] = [
+        `# Comment Deleted`,
+        '',
+        `**Comment ID:** ${targetId}`,
+        '',
+        'The comment has been permanently deleted.',
+    ]
+
+    const structuredContent: DeleteCommentOutput = {
+        type: 'delete_comment_result',
+        success: true,
+        targetType: 'comment',
+        commentId: targetId,
+    }
+
+    return { textContent: lines.join('\n'), structuredContent }
+}
+
+async function deleteMessageBranch(args: Args, client: TwistApi): Promise<Branch> {
+    const { targetId } = args
+
+    await client.conversationMessages.deleteMessage(targetId)
+
+    const lines: string[] = [
+        `# Message Deleted`,
+        '',
+        `**Message ID:** ${targetId}`,
+        '',
+        'The conversation message has been permanently deleted.',
+    ]
+
+    const structuredContent: DeleteMessageOutput = {
+        type: 'delete_message_result',
+        success: true,
+        targetType: 'message',
+        messageId: targetId,
+    }
+
+    return { textContent: lines.join('\n'), structuredContent }
+}
+
+const deleteObject = {
+    name: ToolNames.DELETE_OBJECT,
+    description:
+        'Permanently delete a Twist object. `targetType: "thread"` deletes a thread (and all of its comments); `"comment"` deletes a single thread comment; `"message"` deletes a direct/group conversation message. Always pass `targetId`. Deletion is irreversible — confirm with the user before invoking.',
+    parameters: ArgsSchema,
+    outputSchema: DeleteObjectOutputSchema.shape,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
+    async execute(args, client) {
+        const { targetType } = args
+
+        const branch =
+            targetType === 'thread'
+                ? await deleteThreadBranch(args, client)
+                : targetType === 'comment'
+                  ? await deleteCommentBranch(args, client)
+                  : await deleteMessageBranch(args, client)
+
+        return getToolOutput({
+            textContent: branch.textContent,
+            structuredContent: branch.structuredContent,
+        })
+    },
+} satisfies TwistTool<typeof ArgsSchema, typeof DeleteObjectOutputSchema.shape>
+
+export { deleteObject }

--- a/src/tools/delete-object.ts
+++ b/src/tools/delete-object.ts
@@ -96,7 +96,7 @@ async function deleteMessageBranch(args: Args, client: TwistApi): Promise<Branch
 const deleteObject = {
     name: ToolNames.DELETE_OBJECT,
     description:
-        'Permanently delete a Twist object. `targetType: "thread"` deletes a thread (and all of its comments); `"comment"` deletes a single thread comment; `"message"` deletes a direct/group conversation message. Always pass `targetId`. Deletion is irreversible — confirm with the user before invoking.',
+        'Permanently delete a Twist object. `targetType: "thread"` deletes a thread (and all of its comments); `"comment"` deletes a single thread comment; `"message"` deletes a direct/group conversation message. Always pass `targetId`. Deletion is irreversible — confirm with the user before invoking. Note: the Twist API only allows deletion by the object\'s creator or a workspace admin; the call will be rejected otherwise.',
     parameters: ArgsSchema,
     outputSchema: DeleteObjectOutputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -405,6 +405,55 @@ export const UpdateObjectOutputSchema = z.object({
 })
 
 /**
+ * Schema for delete-thread branch of delete-object output
+ */
+export const DeleteThreadOutputSchema = z.object({
+    type: z.literal('delete_thread_result'),
+    success: z.boolean(),
+    targetType: z.literal('thread'),
+    threadId: z.number(),
+})
+
+/**
+ * Schema for delete-comment branch of delete-object output
+ */
+export const DeleteCommentOutputSchema = z.object({
+    type: z.literal('delete_comment_result'),
+    success: z.boolean(),
+    targetType: z.literal('comment'),
+    commentId: z.number(),
+})
+
+/**
+ * Schema for delete-message branch of delete-object output
+ */
+export const DeleteMessageOutputSchema = z.object({
+    type: z.literal('delete_message_result'),
+    success: z.boolean(),
+    targetType: z.literal('message'),
+    messageId: z.number(),
+})
+
+/**
+ * Schema for delete-object tool output.
+ *
+ * The Twist SDK delete endpoints return no body, so the structured payload simply
+ * confirms which object was deleted. The `type` discriminator selects which
+ * id field is populated:
+ *  - `delete_thread_result`  → threadId
+ *  - `delete_comment_result` → commentId
+ *  - `delete_message_result` → messageId
+ */
+export const DeleteObjectOutputSchema = z.object({
+    type: z.enum(['delete_thread_result', 'delete_comment_result', 'delete_message_result']),
+    success: z.boolean(),
+    targetType: z.enum(['thread', 'comment', 'message']),
+    threadId: z.number().optional(),
+    commentId: z.number().optional(),
+    messageId: z.number().optional(),
+})
+
+/**
  * Schema for reply tool output
  */
 export const ReplyOutputSchema = z.object({
@@ -505,6 +554,9 @@ export const StructuredOutputSchema = z.union([
     UpdateThreadOutputSchema,
     UpdateCommentOutputSchema,
     UpdateMessageOutputSchema,
+    DeleteThreadOutputSchema,
+    DeleteCommentOutputSchema,
+    DeleteMessageOutputSchema,
     ReplyOutputSchema,
     ReactOutputSchema,
     MarkDoneOutputSchema,
@@ -525,6 +577,16 @@ export type UpdateObjectOutput = z.infer<typeof UpdateObjectOutputSchema>
  * to construct structured payloads — `UpdateObjectOutput` is the looser MCP-facing shape.
  */
 export type UpdateObjectStructured = UpdateThreadOutput | UpdateCommentOutput | UpdateMessageOutput
+export type DeleteThreadOutput = z.infer<typeof DeleteThreadOutputSchema>
+export type DeleteCommentOutput = z.infer<typeof DeleteCommentOutputSchema>
+export type DeleteMessageOutput = z.infer<typeof DeleteMessageOutputSchema>
+export type DeleteObjectOutput = z.infer<typeof DeleteObjectOutputSchema>
+
+/**
+ * Strictly-typed union of the three per-branch delete outputs. Use this in the tool
+ * to construct structured payloads — `DeleteObjectOutput` is the looser MCP-facing shape.
+ */
+export type DeleteObjectStructured = DeleteThreadOutput | DeleteCommentOutput | DeleteMessageOutput
 export type AwayOutput = z.infer<typeof AwayOutputSchema>
 export type LoadThreadOutput = z.infer<typeof LoadThreadOutputSchema>
 export type LoadConversationOutput = z.infer<typeof LoadConversationOutputSchema>

--- a/src/utils/target-types.ts
+++ b/src/utils/target-types.ts
@@ -34,6 +34,13 @@ export const UpdateTargetTypeSchema = UpdateTargetType.schema
 export type UpdateTargetType = z.infer<typeof UpdateTargetTypeSchema>
 
 /**
+ * Target types for delete-object
+ */
+export const DeleteTargetType = createEnumSchema(['thread', 'comment', 'message'])
+export const DeleteTargetTypeSchema = DeleteTargetType.schema
+export type DeleteTargetType = z.infer<typeof DeleteTargetTypeSchema>
+
+/**
  * Target types for replies
  */
 export const ReplyTargetType = createEnumSchema(['thread', 'conversation'])

--- a/src/utils/target-types.ts
+++ b/src/utils/target-types.ts
@@ -27,16 +27,23 @@ export const ReactionTargetTypeSchema = ReactionTargetType.schema
 export type ReactionTargetType = z.infer<typeof ReactionTargetTypeSchema>
 
 /**
+ * Targets that can be both updated and deleted (mutating-object tools).
+ * Kept as a shared const so update-object and delete-object stay in lockstep
+ * if/when the supported surface changes.
+ */
+const objectTargets = ['thread', 'comment', 'message'] as const
+
+/**
  * Target types for update-object
  */
-export const UpdateTargetType = createEnumSchema(['thread', 'comment', 'message'])
+export const UpdateTargetType = createEnumSchema(objectTargets)
 export const UpdateTargetTypeSchema = UpdateTargetType.schema
 export type UpdateTargetType = z.infer<typeof UpdateTargetTypeSchema>
 
 /**
  * Target types for delete-object
  */
-export const DeleteTargetType = createEnumSchema(['thread', 'comment', 'message'])
+export const DeleteTargetType = createEnumSchema(objectTargets)
 export const DeleteTargetTypeSchema = DeleteTargetType.schema
 export type DeleteTargetType = z.infer<typeof DeleteTargetTypeSchema>
 

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -7,6 +7,7 @@ export const ToolNames = {
     GET_MENTIONS: 'get-mentions',
     CREATE_THREAD: 'create-thread',
     UPDATE_OBJECT: 'update-object',
+    DELETE_OBJECT: 'delete-object',
     REPLY: 'reply',
     REACT: 'react',
     MARK_DONE: 'mark-done',


### PR DESCRIPTION
## Summary

Adds a unified `delete-object` tool for permanently deleting Twist threads, thread comments, and conversation messages, mirroring the pattern introduced by `update-object` in #182.

A single tool accepts `targetType: "thread" | "comment" | "message"` plus `targetId`, and dispatches to the matching SDK call (`threads.deleteThread`, `comments.deleteComment`, `conversationMessages.deleteMessage`).

## Motivation

The MCP server already supports creating, updating, and replying to objects, but there's no way to remove one once posted. In practice this comes up immediately when an LLM posts a thread to the wrong channel or to an audience that can't see it — today the only fix is for the human to clean up manually in the Twist UI.

## Tool details

- **Name:** `delete-object`
- **Args:** `targetType` (thread/comment/message), `targetId` (number)
- **Annotations:** `readOnlyHint: false`, `destructiveHint: true`, `idempotentHint: true`
- **Description** explicitly warns the model that deletion is irreversible and that deleting a thread also removes its comments
- **Output schema:** confirmation-only (Twist's delete endpoints return no body), with a `type` discriminator (`delete_thread_result` / `delete_comment_result` / `delete_message_result`) and the corresponding id field

## Files touched

Per `AGENTS.md`'s "Adding a New Tool" checklist:

- `src/utils/tool-names.ts` — add `DELETE_OBJECT`
- `src/utils/target-types.ts` — add `DeleteTargetType`
- `src/utils/output-schemas.ts` — add per-branch and union output schemas + types
- `src/tools/delete-object.ts` — new tool
- `src/mcp-server.ts` — import, register, add to LLM `instructions` string
- `src/index.ts` — export
- `scripts/run-tool.ts` — register for direct invocation
- `src/tools/__tests__/tool-annotations.test.ts` — annotation expectation
- `src/tools/__tests__/delete-object.test.ts` — unit tests for all three branches

## Test plan

- [x] `npm run type-check` passes
- [x] `npm test` — 17 suites, 171 tests, 50 snapshots pass
- [x] `npm run format:check` — 0 warnings, 0 errors
- [x] `npm run build` — clean
- [x] New tests cover all three target types (thread / comment / message), error propagation, and routing isolation (only the matching SDK method is called)

## Notes

- The SDK delete methods return `Promise<void>`, so the structured output is intentionally minimal — just the discriminator, the id, and `success: true`. Errors propagate from the SDK as-is.
- `idempotentHint: true` matches the MCP spec semantics for delete (calling it twice has the same effect as calling it once, modulo a possible 404 on the second call).