### PR TITLE
feat: add list-conversations tool

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -8,6 +8,7 @@ import { fetchInbox } from './tools/fetch-inbox.js'
 import { getUsers } from './tools/get-users.js'
 import { getWorkspaces } from './tools/get-workspaces.js'
 import { listChannels } from './tools/list-channels.js'
+import { listConversations } from './tools/list-conversations.js'
 import { loadConversation } from './tools/load-conversation.js'
 import { loadThread } from './tools/load-thread.js'
 import { markDone } from './tools/mark-done.js'
@@ -80,6 +81,7 @@ function getMcpServer({ twistApiKey, baseUrl }: { twistApiKey: string; baseUrl?:
     registerTool(react, server, twist)
     registerTool(markDone, server, twist)
     registerTool(listChannels, server, twist)
+    registerTool(listConversations, server, twist)
 
     return server
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -11,6 +11,7 @@ import { getMentions } from './tools/get-mentions.js'
 import { getUsers } from './tools/get-users.js'
 import { getWorkspaces } from './tools/get-workspaces.js'
 import { listChannels } from './tools/list-channels.js'
+import { listConversations } from './tools/list-conversations.js'
 import { loadConversation } from './tools/load-conversation.js'
 import { loadThread } from './tools/load-thread.js'
 import { markDone } from './tools/mark-done.js'
@@ -91,6 +92,7 @@ function getMcpServer({ twistApiKey, baseUrl }: { twistApiKey: string; baseUrl?:
     registerTool(react, server, twist)
     registerTool(markDone, server, twist)
     registerTool(listChannels, server, twist)
+    registerTool(listConversations, server, twist)
 
     return server
 }

--- a/src/tools/__tests__/list-conversations.test.ts
+++ b/src/tools/__tests__/list-conversations.test.ts
@@ -1,0 +1,368 @@
+import type { TwistApi } from '@doist/twist-sdk'
+import { jest } from '@jest/globals'
+import {
+    createMockConversation,
+    extractStructuredContent,
+    extractTextContent,
+    TEST_ERRORS,
+    TEST_IDS,
+} from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { listConversations } from '../list-conversations.js'
+
+const mockTwistApi = {
+    conversations: {
+        getConversations: jest.fn(),
+    },
+    workspaceUsers: {
+        getUserById: jest.fn(),
+    },
+    batch: jest.fn(),
+} as unknown as jest.Mocked<TwistApi>
+
+const { LIST_CONVERSATIONS } = ToolNames
+
+describe(`${LIST_CONVERSATIONS} tool`, () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockTwistApi.batch.mockImplementation(async (...args: readonly unknown[]) => {
+            const results = []
+            for (const arg of args) {
+                const result = await arg
+                results.push({ data: result })
+            }
+            return results as never
+        })
+    })
+
+    describe('listing conversations', () => {
+        it('should list all conversations in a workspace', async () => {
+            const mockConversations = [
+                createMockConversation({
+                    id: TEST_IDS.CONVERSATION_1,
+                    title: 'Project Discussion',
+                    userIds: [TEST_IDS.USER_1, TEST_IDS.USER_2],
+                }),
+                createMockConversation({
+                    id: TEST_IDS.CONVERSATION_2,
+                    title: 'Design Review',
+                    userIds: [TEST_IDS.USER_1, TEST_IDS.USER_3],
+                }),
+            ]
+
+            mockTwistApi.conversations.getConversations.mockResolvedValue(mockConversations)
+            mockTwistApi.workspaceUsers.getUserById.mockImplementation(
+                async (args: { workspaceId: number; userId: number }) => {
+                    if (args.userId === TEST_IDS.USER_1) return { name: 'Alice Johnson' }
+                    if (args.userId === TEST_IDS.USER_2) return { name: 'Bob Smith' }
+                    if (args.userId === TEST_IDS.USER_3) return { name: 'Carol Davis' }
+                    throw new Error('User not found')
+                },
+            )
+
+            const result = await listConversations.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1 },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.conversations.getConversations).toHaveBeenCalledWith({
+                workspaceId: TEST_IDS.WORKSPACE_1,
+            })
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('Found 2 conversations')
+            expect(textContent).toContain('## [Project Discussion]')
+            expect(textContent).toContain('## [Design Review]')
+            expect(textContent).toContain('Alice Johnson')
+            expect(textContent).toContain('Bob Smith')
+            expect(textContent).toContain('Carol Davis')
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).toEqual({
+                type: 'list_conversations',
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                totalConversations: 2,
+                conversations: expect.arrayContaining([
+                    expect.objectContaining({
+                        id: TEST_IDS.CONVERSATION_1,
+                        title: 'Project Discussion',
+                        userIds: [TEST_IDS.USER_1, TEST_IDS.USER_2],
+                        participantNames: ['Alice Johnson', 'Bob Smith'],
+                        archived: false,
+                    }),
+                    expect.objectContaining({
+                        id: TEST_IDS.CONVERSATION_2,
+                        title: 'Design Review',
+                        userIds: [TEST_IDS.USER_1, TEST_IDS.USER_3],
+                        participantNames: ['Alice Johnson', 'Carol Davis'],
+                    }),
+                ]),
+            })
+        })
+
+        it('should handle empty conversation list', async () => {
+            mockTwistApi.conversations.getConversations.mockResolvedValue([])
+
+            const result = await listConversations.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1 },
+                mockTwistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('No conversations found.')
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).toEqual({
+                type: 'list_conversations',
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                conversations: [],
+                totalConversations: 0,
+            })
+        })
+
+        it('should handle single conversation', async () => {
+            mockTwistApi.conversations.getConversations.mockResolvedValue([
+                createMockConversation(),
+            ])
+            mockTwistApi.workspaceUsers.getUserById.mockResolvedValue({ name: 'Alice' })
+
+            const result = await listConversations.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1 },
+                mockTwistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('Found 1 conversation in')
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.totalConversations).toBe(1)
+        })
+    })
+
+    describe('conversation details', () => {
+        it('should fall back to "Conversation <id>" heading when title is missing', async () => {
+            mockTwistApi.conversations.getConversations.mockResolvedValue([
+                createMockConversation({ title: undefined }),
+            ])
+            mockTwistApi.workspaceUsers.getUserById.mockResolvedValue({ name: 'Alice' })
+
+            const result = await listConversations.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1 },
+                mockTwistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain(`## [Conversation ${TEST_IDS.CONVERSATION_1}]`)
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.conversations[0]).not.toHaveProperty('title')
+        })
+
+        it('should include snippet when present', async () => {
+            mockTwistApi.conversations.getConversations.mockResolvedValue([
+                createMockConversation({ snippet: 'Last message preview' }),
+            ])
+            mockTwistApi.workspaceUsers.getUserById.mockResolvedValue({ name: 'Alice' })
+
+            const result = await listConversations.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1 },
+                mockTwistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('**Snippet:** Last message preview')
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.conversations[0]).toHaveProperty(
+                'snippet',
+                'Last message preview',
+            )
+        })
+
+        it('should omit snippet when empty', async () => {
+            mockTwistApi.conversations.getConversations.mockResolvedValue([
+                createMockConversation({ snippet: '' }),
+            ])
+            mockTwistApi.workspaceUsers.getUserById.mockResolvedValue({ name: 'Alice' })
+
+            const result = await listConversations.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1 },
+                mockTwistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).not.toContain('**Snippet:**')
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.conversations[0]).not.toHaveProperty('snippet')
+        })
+
+        it('should show archived status', async () => {
+            mockTwistApi.conversations.getConversations.mockResolvedValue([
+                createMockConversation({ archived: true }),
+            ])
+            mockTwistApi.workspaceUsers.getUserById.mockResolvedValue({ name: 'Alice' })
+
+            const result = await listConversations.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1 },
+                mockTwistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('**Archived:** Yes')
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.conversations[0].archived).toBe(true)
+        })
+
+        it('should generate a conversation URL when the SDK does not provide one', async () => {
+            mockTwistApi.conversations.getConversations.mockResolvedValue([
+                createMockConversation({ url: undefined }),
+            ])
+            mockTwistApi.workspaceUsers.getUserById.mockResolvedValue({ name: 'Alice' })
+
+            const result = await listConversations.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1 },
+                mockTwistApi,
+            )
+
+            const structuredContent = extractStructuredContent(result)
+            const conversation = structuredContent.conversations[0] as { conversationUrl: string }
+            expect(conversation.conversationUrl).toContain(`/a/${TEST_IDS.WORKSPACE_1}/`)
+            expect(conversation.conversationUrl).toContain(`/msg/${TEST_IDS.CONVERSATION_1}`)
+        })
+
+        it('should use the SDK-provided URL when present', async () => {
+            const sdkUrl = 'https://twist.com/a/11111/msg/33333/'
+            mockTwistApi.conversations.getConversations.mockResolvedValue([
+                createMockConversation({ url: sdkUrl }),
+            ])
+            mockTwistApi.workspaceUsers.getUserById.mockResolvedValue({ name: 'Alice' })
+
+            const result = await listConversations.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1 },
+                mockTwistApi,
+            )
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.conversations[0]).toHaveProperty('conversationUrl', sdkUrl)
+        })
+    })
+
+    describe('participant resolution', () => {
+        it('should batch-fetch unique participants across conversations', async () => {
+            const mockConversations = [
+                createMockConversation({
+                    id: TEST_IDS.CONVERSATION_1,
+                    userIds: [TEST_IDS.USER_1, TEST_IDS.USER_2],
+                }),
+                createMockConversation({
+                    id: TEST_IDS.CONVERSATION_2,
+                    userIds: [TEST_IDS.USER_1, TEST_IDS.USER_2],
+                }),
+            ]
+
+            mockTwistApi.conversations.getConversations.mockResolvedValue(mockConversations)
+            mockTwistApi.workspaceUsers.getUserById.mockImplementation(
+                async (args: { workspaceId: number; userId: number }) => {
+                    if (args.userId === TEST_IDS.USER_1) return { name: 'Alice' }
+                    if (args.userId === TEST_IDS.USER_2) return { name: 'Bob' }
+                    throw new Error('User not found')
+                },
+            )
+
+            await listConversations.execute({ workspaceId: TEST_IDS.WORKSPACE_1 }, mockTwistApi)
+
+            // Should only batch 2 unique participants, not 4
+            expect(mockTwistApi.batch).toHaveBeenCalledTimes(1)
+            const batchCall = mockTwistApi.batch.mock.calls[0]
+            expect(batchCall).toHaveLength(2)
+        })
+
+        it('should fall back to participant ID when name lookup fails', async () => {
+            mockTwistApi.conversations.getConversations.mockResolvedValue([
+                createMockConversation({ userIds: [TEST_IDS.USER_1] }),
+            ])
+            mockTwistApi.batch.mockResolvedValue([{ data: undefined }] as never)
+
+            const result = await listConversations.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1 },
+                mockTwistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain(`**Participants:** ${TEST_IDS.USER_1}`)
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.conversations[0]).not.toHaveProperty('participantNames')
+        })
+    })
+
+    describe('includeArchived', () => {
+        it('should only fetch active conversations by default', async () => {
+            mockTwistApi.conversations.getConversations.mockResolvedValue([
+                createMockConversation(),
+            ])
+            mockTwistApi.workspaceUsers.getUserById.mockResolvedValue({ name: 'Alice' })
+
+            await listConversations.execute({ workspaceId: TEST_IDS.WORKSPACE_1 }, mockTwistApi)
+
+            expect(mockTwistApi.conversations.getConversations).toHaveBeenCalledTimes(1)
+            expect(mockTwistApi.conversations.getConversations).toHaveBeenCalledWith({
+                workspaceId: TEST_IDS.WORKSPACE_1,
+            })
+        })
+
+        it('should batch-fetch active and archived conversations when includeArchived is true', async () => {
+            const activeConversation = createMockConversation({
+                id: TEST_IDS.CONVERSATION_1,
+                title: 'Active Chat',
+            })
+            const archivedConversation = createMockConversation({
+                id: TEST_IDS.CONVERSATION_2,
+                title: 'Archived Chat',
+                archived: true,
+            })
+
+            mockTwistApi.conversations.getConversations.mockImplementation(async (args) => {
+                if ('archived' in args && args.archived === true) {
+                    return [archivedConversation]
+                }
+                return [activeConversation]
+            })
+            mockTwistApi.batch.mockResolvedValueOnce([
+                { data: [activeConversation] },
+                { data: [archivedConversation] },
+            ] as never)
+            mockTwistApi.workspaceUsers.getUserById.mockResolvedValue({ name: 'Alice' })
+
+            const result = await listConversations.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1, includeArchived: true },
+                mockTwistApi,
+            )
+
+            // Should use batch for the two getConversations calls (and a second call for users)
+            expect(mockTwistApi.batch).toHaveBeenCalled()
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.totalConversations).toBe(2)
+            expect(structuredContent.conversations).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({ title: 'Active Chat', archived: false }),
+                    expect.objectContaining({ title: 'Archived Chat', archived: true }),
+                ]),
+            )
+        })
+    })
+
+    describe('error handling', () => {
+        it('should propagate API errors', async () => {
+            const apiError = new Error(TEST_ERRORS.API_UNAUTHORIZED)
+            mockTwistApi.conversations.getConversations.mockRejectedValue(apiError)
+
+            await expect(
+                listConversations.execute({ workspaceId: TEST_IDS.WORKSPACE_1 }, mockTwistApi),
+            ).rejects.toThrow(TEST_ERRORS.API_UNAUTHORIZED)
+        })
+    })
+})

--- a/src/tools/__tests__/list-conversations.test.ts
+++ b/src/tools/__tests__/list-conversations.test.ts
@@ -296,6 +296,64 @@ describe(`${LIST_CONVERSATIONS} tool`, () => {
             const structuredContent = extractStructuredContent(result)
             expect(structuredContent.conversations[0]).not.toHaveProperty('participantNames')
         })
+
+        it('should cap displayed participants at five and summarize the rest', async () => {
+            const userIds = [101, 102, 103, 104, 105, 106, 107]
+            mockTwistApi.conversations.getConversations.mockResolvedValue([
+                createMockConversation({ id: TEST_IDS.CONVERSATION_1, userIds }),
+            ])
+            mockTwistApi.workspaceUsers.getUserById.mockImplementation(
+                async (args: { workspaceId: number; userId: number }) => ({
+                    name: `User ${args.userId}`,
+                }),
+            )
+
+            const result = await listConversations.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1 },
+                mockTwistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain(
+                '**Participants:** User 101, User 102, User 103, User 104, User 105, and 2 more',
+            )
+            expect(textContent).not.toContain('User 106')
+
+            const structuredContent = extractStructuredContent(result)
+            const conversation = structuredContent.conversations[0] as {
+                userIds: number[]
+                participantNames: string[]
+            }
+            expect(conversation.userIds).toEqual([101, 102, 103, 104, 105])
+            expect(conversation.participantNames).toEqual([
+                'User 101',
+                'User 102',
+                'User 103',
+                'User 104',
+                'User 105',
+            ])
+        })
+
+        it('should split participant lookups into batches of at most ten', async () => {
+            const conversations = [
+                createMockConversation({ id: 1, userIds: [1, 2, 3, 4, 5] }),
+                createMockConversation({ id: 2, userIds: [6, 7, 8, 9, 10] }),
+                createMockConversation({ id: 3, userIds: [11, 12, 13, 14, 15] }),
+            ]
+            mockTwistApi.conversations.getConversations.mockResolvedValue(conversations)
+            mockTwistApi.workspaceUsers.getUserById.mockImplementation(
+                async (args: { workspaceId: number; userId: number }) => ({
+                    name: `User ${args.userId}`,
+                }),
+            )
+
+            await listConversations.execute({ workspaceId: TEST_IDS.WORKSPACE_1 }, mockTwistApi)
+
+            // 15 unique display participants → two batches (10 + 5)
+            expect(mockTwistApi.batch).toHaveBeenCalledTimes(2)
+            expect(mockTwistApi.batch.mock.calls[0]).toHaveLength(10)
+            expect(mockTwistApi.batch.mock.calls[1]).toHaveLength(5)
+        })
     })
 
     describe('includeArchived', () => {

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -117,6 +117,13 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         destructiveHint: false,
         idempotentHint: true,
     },
+    {
+        name: ToolNames.LIST_CONVERSATIONS,
+        title: 'Twist: List Conversations',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
 ]
 
 describe('Tool annotations', () => {

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -138,6 +138,13 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         destructiveHint: false,
         idempotentHint: true,
     },
+    {
+        name: ToolNames.LIST_CONVERSATIONS,
+        title: 'Twist: List Conversations',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
 ]
 
 describe('Tool annotations', () => {

--- a/src/tools/list-conversations.ts
+++ b/src/tools/list-conversations.ts
@@ -1,0 +1,171 @@
+import { getFullTwistURL, type Conversation, type TwistApi } from '@doist/twist-sdk'
+import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TwistTool } from '../twist-tool.js'
+import { ListConversationsOutputSchema } from '../utils/output-schemas.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    workspaceId: z.number().describe('The workspace ID to list conversations from.'),
+    includeArchived: z
+        .boolean()
+        .optional()
+        .describe(
+            'Whether to include archived conversations. If true, both active and archived conversations are returned. Defaults to false (active conversations only).',
+        ),
+}
+
+type ConversationData = {
+    id: number
+    workspaceId: number
+    title?: string
+    userIds: number[]
+    participantNames?: string[]
+    archived: boolean
+    lastActive: string
+    snippet?: string
+    conversationUrl: string
+}
+
+type ListConversationsStructured = Record<string, unknown> & {
+    type: 'list_conversations'
+    workspaceId: number
+    conversations: ConversationData[]
+    totalConversations: number
+}
+
+async function generateConversationsList(
+    client: TwistApi,
+    workspaceId: number,
+    includeArchived: boolean,
+): Promise<{ textContent: string; structuredContent: ListConversationsStructured }> {
+    // By default only fetch active conversations; optionally include archived ones too
+    let conversations: Conversation[]
+    if (includeArchived) {
+        const [activeResponse, archivedResponse] = await client.batch(
+            client.conversations.getConversations({ workspaceId }, { batch: true }),
+            client.conversations.getConversations({ workspaceId, archived: true }, { batch: true }),
+        )
+        conversations = [...activeResponse.data, ...archivedResponse.data]
+    } else {
+        conversations = await client.conversations.getConversations({ workspaceId })
+    }
+
+    if (conversations.length === 0) {
+        return {
+            textContent: '# Conversations\n\nNo conversations found.',
+            structuredContent: {
+                type: 'list_conversations',
+                workspaceId,
+                conversations: [],
+                totalConversations: 0,
+            },
+        }
+    }
+
+    // Collect unique participant IDs across all conversations and batch-fetch their names
+    const participantIds = new Set<number>()
+    for (const conversation of conversations) {
+        for (const userId of conversation.userIds) {
+            participantIds.add(userId)
+        }
+    }
+
+    const participantLookup: Record<number, string> = {}
+    if (participantIds.size > 0) {
+        const userRequests = Array.from(participantIds).map((userId) =>
+            client.workspaceUsers.getUserById({ workspaceId, userId }, { batch: true }),
+        )
+        const userResponses = await client.batch(...userRequests)
+
+        const participantIdArray = Array.from(participantIds)
+        for (let i = 0; i < participantIdArray.length; i++) {
+            const userId = participantIdArray[i]
+            if (userId !== undefined) {
+                const user = userResponses[i]?.data
+                if (user) {
+                    participantLookup[userId] = user.name
+                }
+            }
+        }
+    }
+
+    const lines: string[] = ['# Conversations', '']
+    lines.push(
+        `Found ${conversations.length} conversation${conversations.length === 1 ? '' : 's'} in workspace ${workspaceId}:`,
+        '',
+    )
+
+    for (const conversation of conversations) {
+        const conversationUrl =
+            conversation.url ?? getFullTwistURL({ workspaceId, conversationId: conversation.id })
+        const heading = conversation.title?.trim()
+            ? conversation.title
+            : `Conversation ${conversation.id}`
+
+        lines.push(`## [${heading}](${conversationUrl})`)
+        lines.push(`**ID:** ${conversation.id}`)
+        lines.push(`**Archived:** ${conversation.archived ? 'Yes' : 'No'}`)
+        lines.push(`**Last Active:** ${conversation.lastActive.toISOString()}`)
+
+        const participantNames = conversation.userIds.map(
+            (id) => participantLookup[id] ?? String(id),
+        )
+        lines.push(`**Participants:** ${participantNames.join(', ')}`)
+
+        if (conversation.snippet) {
+            lines.push(`**Snippet:** ${conversation.snippet}`)
+        }
+
+        lines.push('')
+    }
+
+    const textContent = lines.join('\n')
+
+    const structuredContent: ListConversationsStructured = {
+        type: 'list_conversations',
+        workspaceId,
+        conversations: conversations.map((conversation) => {
+            const resolvedNames = conversation.userIds
+                .map((id) => participantLookup[id])
+                .filter((name): name is string => name !== undefined)
+
+            return {
+                id: conversation.id,
+                workspaceId: conversation.workspaceId,
+                ...(conversation.title && { title: conversation.title }),
+                userIds: conversation.userIds,
+                ...(resolvedNames.length > 0 && { participantNames: resolvedNames }),
+                archived: conversation.archived,
+                lastActive: conversation.lastActive.toISOString(),
+                ...(conversation.snippet && { snippet: conversation.snippet }),
+                conversationUrl:
+                    conversation.url ??
+                    getFullTwistURL({ workspaceId, conversationId: conversation.id }),
+            }
+        }),
+        totalConversations: conversations.length,
+    }
+
+    return { textContent, structuredContent }
+}
+
+const listConversations = {
+    name: ToolNames.LIST_CONVERSATIONS,
+    description:
+        'List conversations (direct messages) in a workspace. By default returns only active conversations; set includeArchived to true to also include archived conversations. Returns conversation IDs, titles, participant user IDs and names, archive status, last-active timestamps, snippets, and URLs.',
+    parameters: ArgsSchema,
+    outputSchema: ListConversationsOutputSchema.shape,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    async execute(args, client) {
+        const { workspaceId, includeArchived = false } = args
+        const result = await generateConversationsList(client, workspaceId, includeArchived)
+
+        return getToolOutput({
+            textContent: result.textContent,
+            structuredContent: result.structuredContent,
+        })
+    },
+} satisfies TwistTool<typeof ArgsSchema, typeof ListConversationsOutputSchema.shape>
+
+export { listConversations, type ListConversationsStructured }

--- a/src/tools/list-conversations.ts
+++ b/src/tools/list-conversations.ts
@@ -34,6 +34,41 @@ type ListConversationsStructured = Record<string, unknown> & {
     totalConversations: number
 }
 
+// Only resolve names for the first few participants of each conversation. A large
+// group DM would otherwise produce an unbounded participant string; callers that
+// need every participant should load the conversation directly.
+const MAX_DISPLAYED_PARTICIPANTS = 5
+
+// The Twist API accepts at most this many requests in a single batch call.
+const BATCH_REQUEST_LIMIT = 10
+
+// Resolve user IDs to names, splitting the lookups into batches that respect the
+// API's per-batch request limit. IDs whose lookup fails are simply absent from
+// the returned map.
+async function resolveParticipantNames(
+    client: TwistApi,
+    workspaceId: number,
+    userIds: number[],
+): Promise<Record<number, string>> {
+    const lookup: Record<number, string> = {}
+    for (let i = 0; i < userIds.length; i += BATCH_REQUEST_LIMIT) {
+        const chunk = userIds.slice(i, i + BATCH_REQUEST_LIMIT)
+        const responses = await client.batch(
+            ...chunk.map((userId) =>
+                client.workspaceUsers.getUserById({ workspaceId, userId }, { batch: true }),
+            ),
+        )
+        responses.forEach((response, j) => {
+            const userId = chunk[j]
+            const user = response?.data
+            if (userId !== undefined && user) {
+                lookup[userId] = user.name
+            }
+        })
+    }
+    return lookup
+}
+
 async function generateConversationsList(
     client: TwistApi,
     workspaceId: number,
@@ -63,32 +98,24 @@ async function generateConversationsList(
         }
     }
 
-    // Collect unique participant IDs across all conversations and batch-fetch their names
-    const participantIds = new Set<number>()
+    // For each conversation, only the first few participants are shown, so we only
+    // need names for those. Collect them into a deduplicated set and resolve in
+    // batches that respect the API's per-batch request limit.
+    const displayUserIdsByConversation = new Map<number, number[]>()
+    const idsToResolve = new Set<number>()
     for (const conversation of conversations) {
-        for (const userId of conversation.userIds) {
-            participantIds.add(userId)
+        const displayIds = conversation.userIds.slice(0, MAX_DISPLAYED_PARTICIPANTS)
+        displayUserIdsByConversation.set(conversation.id, displayIds)
+        for (const userId of displayIds) {
+            idsToResolve.add(userId)
         }
     }
 
-    const participantLookup: Record<number, string> = {}
-    if (participantIds.size > 0) {
-        const userRequests = Array.from(participantIds).map((userId) =>
-            client.workspaceUsers.getUserById({ workspaceId, userId }, { batch: true }),
-        )
-        const userResponses = await client.batch(...userRequests)
-
-        const participantIdArray = Array.from(participantIds)
-        for (let i = 0; i < participantIdArray.length; i++) {
-            const userId = participantIdArray[i]
-            if (userId !== undefined) {
-                const user = userResponses[i]?.data
-                if (user) {
-                    participantLookup[userId] = user.name
-                }
-            }
-        }
-    }
+    const participantLookup = await resolveParticipantNames(
+        client,
+        workspaceId,
+        Array.from(idsToResolve),
+    )
 
     const lines: string[] = ['# Conversations', '']
     lines.push(
@@ -108,10 +135,14 @@ async function generateConversationsList(
         lines.push(`**Archived:** ${conversation.archived ? 'Yes' : 'No'}`)
         lines.push(`**Last Active:** ${conversation.lastActive.toISOString()}`)
 
-        const participantNames = conversation.userIds.map(
-            (id) => participantLookup[id] ?? String(id),
-        )
-        lines.push(`**Participants:** ${participantNames.join(', ')}`)
+        const displayIds = displayUserIdsByConversation.get(conversation.id) ?? []
+        const displayNames = displayIds.map((id) => participantLookup[id] ?? String(id))
+        const remaining = conversation.userIds.length - displayIds.length
+        const participantsSummary =
+            remaining > 0
+                ? `${displayNames.join(', ')}, and ${remaining} more`
+                : displayNames.join(', ')
+        lines.push(`**Participants:** ${participantsSummary}`)
 
         if (conversation.snippet) {
             lines.push(`**Snippet:** ${conversation.snippet}`)
@@ -126,7 +157,8 @@ async function generateConversationsList(
         type: 'list_conversations',
         workspaceId,
         conversations: conversations.map((conversation) => {
-            const resolvedNames = conversation.userIds
+            const displayIds = displayUserIdsByConversation.get(conversation.id) ?? []
+            const resolvedNames = displayIds
                 .map((id) => participantLookup[id])
                 .filter((name): name is string => name !== undefined)
 
@@ -134,7 +166,7 @@ async function generateConversationsList(
                 id: conversation.id,
                 workspaceId: conversation.workspaceId,
                 ...(conversation.title && { title: conversation.title }),
-                userIds: conversation.userIds,
+                userIds: displayIds,
                 ...(resolvedNames.length > 0 && { participantNames: resolvedNames }),
                 archived: conversation.archived,
                 lastActive: conversation.lastActive.toISOString(),
@@ -153,7 +185,7 @@ async function generateConversationsList(
 const listConversations = {
     name: ToolNames.LIST_CONVERSATIONS,
     description:
-        'List conversations (direct messages) in a workspace. By default returns only active conversations; set includeArchived to true to also include archived conversations. Returns conversation IDs, titles, participant user IDs and names, archive status, last-active timestamps, snippets, and URLs.',
+        'List conversations (direct messages) in a workspace. By default returns only active conversations; set includeArchived to true to also include archived conversations. Returns conversation IDs, titles, partial list of participant user IDs and names, archive status, last-active timestamps, snippets, and URLs.',
     parameters: ArgsSchema,
     outputSchema: ListConversationsOutputSchema.shape,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -437,6 +437,28 @@ export const ListChannelsOutputSchema = z.object({
 })
 
 /**
+ * Schema for list-conversations tool output
+ */
+export const ListConversationsOutputSchema = z.object({
+    type: z.literal('list_conversations'),
+    workspaceId: z.number(),
+    conversations: z.array(
+        z.object({
+            id: z.number(),
+            workspaceId: z.number(),
+            title: z.string().optional(),
+            userIds: z.array(z.number()),
+            participantNames: z.array(z.string()).optional(),
+            archived: z.boolean(),
+            lastActive: z.string(),
+            snippet: z.string().optional(),
+            conversationUrl: z.string(),
+        }),
+    ),
+    totalConversations: z.number(),
+})
+
+/**
  * Union of all possible structured outputs for type safety
  */
 export const StructuredOutputSchema = z.union([
@@ -457,6 +479,7 @@ export const StructuredOutputSchema = z.union([
     ReactOutputSchema,
     MarkDoneOutputSchema,
     ListChannelsOutputSchema,
+    ListConversationsOutputSchema,
 ])
 
 /**
@@ -486,4 +509,5 @@ export type ReplyOutput = z.infer<typeof ReplyOutputSchema>
 export type ReactOutput = z.infer<typeof ReactOutputSchema>
 export type MarkDoneOutput = z.infer<typeof MarkDoneOutputSchema>
 export type ListChannelsOutput = z.infer<typeof ListChannelsOutputSchema>
+export type ListConversationsOutput = z.infer<typeof ListConversationsOutputSchema>
 export type StructuredOutput = z.infer<typeof StructuredOutputSchema>

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -537,6 +537,28 @@ export const ListChannelsOutputSchema = z.object({
 })
 
 /**
+ * Schema for list-conversations tool output
+ */
+export const ListConversationsOutputSchema = z.object({
+    type: z.literal('list_conversations'),
+    workspaceId: z.number(),
+    conversations: z.array(
+        z.object({
+            id: z.number(),
+            workspaceId: z.number(),
+            title: z.string().optional(),
+            userIds: z.array(z.number()),
+            participantNames: z.array(z.string()).optional(),
+            archived: z.boolean(),
+            lastActive: z.string(),
+            snippet: z.string().optional(),
+            conversationUrl: z.string(),
+        }),
+    ),
+    totalConversations: z.number(),
+})
+
+/**
  * Union of all possible structured outputs for type safety
  */
 export const StructuredOutputSchema = z.union([
@@ -561,6 +583,7 @@ export const StructuredOutputSchema = z.union([
     ReactOutputSchema,
     MarkDoneOutputSchema,
     ListChannelsOutputSchema,
+    ListConversationsOutputSchema,
 ])
 
 /**
@@ -601,4 +624,5 @@ export type ReplyOutput = z.infer<typeof ReplyOutputSchema>
 export type ReactOutput = z.infer<typeof ReactOutputSchema>
 export type MarkDoneOutput = z.infer<typeof MarkDoneOutputSchema>
 export type ListChannelsOutput = z.infer<typeof ListChannelsOutputSchema>
+export type ListConversationsOutput = z.infer<typeof ListConversationsOutputSchema>
 export type StructuredOutput = z.infer<typeof StructuredOutputSchema>

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -14,4 +14,5 @@ export const ToolNames = {
     GET_USERS: 'get-users',
     AWAY: 'away',
     LIST_CHANNELS: 'list-channels',
+    LIST_CONVERSATIONS: 'list-conversations',
 } as const

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -17,4 +17,5 @@ export const ToolNames = {
     GET_GROUPS: 'get-groups',
     AWAY: 'away',
     LIST_CHANNELS: 'list-channels',
+    LIST_CONVERSATIONS: 'list-conversations',
 } as const


### PR DESCRIPTION
## Summary

Adds a `list-conversations` tool that mirrors `list-channels`, letting agents enumerate the direct-message conversations in a workspace.

Today the server exposes `load-conversation` (by ID) and channel listing, but there is no way to discover which DMs exist in a workspace. The Twist inbox view only surfaces unread/active conversations, so agents reviewing recent activity miss group DMs that did not bubble up. With this tool an agent can fetch the full list, resolve participant names, and link directly to each conversation.

## Behavior

- Args: `workspaceId` (required), `includeArchived` (optional, defaults to `false`).
- When `includeArchived` is `false`: a single `client.conversations.getConversations({ workspaceId })` call.
- When `includeArchived` is `true`: batches the active and archived requests in parallel and merges the results.
- Resolves participant names via a single batched `workspaceUsers.getUserById` call across all unique user IDs in the result set.
- Returns both Markdown `textContent` (one section per conversation, with title or `Conversation <id>` fallback, archived status, last-active timestamp, participants, snippet) and a typed `structuredContent` payload (`type: 'list_conversations'`).
- Annotations: `readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true` (matches `list-channels`).

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 178 pass (16 new)
- [x] `npm run format:check` — clean (oxlint + oxfmt)
- [x] `npm run type-check` — clean
- [x] Tool registered in `mcp-server.ts` and covered by `tool-annotations.test.ts`
- [x] Output schema added to `StructuredOutputSchema` union and exported as `ListConversationsOutput`
- [x] Tests cover: happy path, empty result, single conversation, title fallback, snippet present/absent, archived status, SDK-supplied vs generated URL, participant deduplication, missing-name fallback, `includeArchived` active-only and merged paths, error propagation