### PR TITLE
feat: add get-mentions tool for fetching user mentions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "5.0.0",
             "license": "MIT",
             "dependencies": {
-                "@doist/twist-sdk": "2.4.1",
+                "@doist/twist-sdk": "2.5.0",
                 "dotenv": "17.4.2",
                 "zod": "4.1.13"
             },
@@ -593,9 +593,9 @@
             }
         },
         "node_modules/@doist/twist-sdk": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.4.1.tgz",
-            "integrity": "sha512-a5QtVBTC3+BzziNrzKfS6/NIsceACcxiuJS7RB9RGVjullifwZf+5EFBFabWfpOXiDhZCoZrSkd91KhC5fcnxg==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@doist/twist-sdk/-/twist-sdk-2.5.0.tgz",
+            "integrity": "sha512-PBBYZ8dVdaO3DXdyNL0PFXBn0xIt9g+U4ANMT6rPknKMc1uMkgfI8CZ5EsU6Rj0sE0EVYnmrlLNPsj82JcM5pw==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "prepublishOnly": "npm run build && npm test"
     },
     "dependencies": {
-        "@doist/twist-sdk": "2.4.1",
+        "@doist/twist-sdk": "2.5.0",
         "dotenv": "17.4.2",
         "zod": "4.1.13"
     },

--- a/scripts/run-tool.ts
+++ b/scripts/run-tool.ts
@@ -21,6 +21,7 @@ import { away } from '../src/tools/away.js'
 import { buildLink } from '../src/tools/build-link.js'
 import { createThread } from '../src/tools/create-thread.js'
 import { fetchInbox } from '../src/tools/fetch-inbox.js'
+import { getMentions } from '../src/tools/get-mentions.js'
 import { getUsers } from '../src/tools/get-users.js'
 import { getWorkspaces } from '../src/tools/get-workspaces.js'
 import { listChannels } from '../src/tools/list-channels.js'
@@ -53,6 +54,7 @@ const tools: Record<string, ExecutableTool> = {
     'load-thread': loadThread,
     'load-conversation': loadConversation,
     'search-content': searchContent,
+    'get-mentions': getMentions,
     'create-thread': createThread,
     'update-object': updateObject,
     reply: reply,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { away } from './tools/away.js'
 import { buildLink } from './tools/build-link.js'
 import { createThread } from './tools/create-thread.js'
 import { fetchInbox } from './tools/fetch-inbox.js'
+import { getMentions } from './tools/get-mentions.js'
 import { listChannels } from './tools/list-channels.js'
 import { loadConversation } from './tools/load-conversation.js'
 import { loadThread } from './tools/load-thread.js'
@@ -20,6 +21,7 @@ const tools = {
     loadThread,
     loadConversation,
     searchContent,
+    getMentions,
     createThread,
     updateObject,
     reply,
@@ -38,6 +40,7 @@ export {
     loadThread,
     loadConversation,
     searchContent,
+    getMentions,
     createThread,
     updateObject,
     reply,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -5,6 +5,7 @@ import { away } from './tools/away.js'
 import { buildLink } from './tools/build-link.js'
 import { createThread } from './tools/create-thread.js'
 import { fetchInbox } from './tools/fetch-inbox.js'
+import { getMentions } from './tools/get-mentions.js'
 import { getUsers } from './tools/get-users.js'
 import { getWorkspaces } from './tools/get-workspaces.js'
 import { listChannels } from './tools/list-channels.js'
@@ -73,6 +74,7 @@ function getMcpServer({ twistApiKey, baseUrl }: { twistApiKey: string; baseUrl?:
     registerTool(loadThread, server, twist)
     registerTool(loadConversation, server, twist)
     registerTool(searchContent, server, twist)
+    registerTool(getMentions, server, twist)
     registerTool(buildLink, server, twist)
     registerTool(createThread, server, twist)
     registerTool(updateObject, server, twist)

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -33,6 +33,7 @@ You have access to comprehensive Twist management tools for team communication a
 
 - **fetch-inbox**: Use to fetch inbox threads for a workspace, along with unread conversations and counts. Supports archiveFilter values of active, archived, or all; use all when the user needs both open and done threads. Optionally set onlyUnread to focus on unread items.
 - **list-channels**: Use to discover channels in a workspace. Requires a workspace ID. Optionally set includeArchived to true to also list archived channels. Returns channel names, IDs, descriptions, visibility, archive status, and URLs.
+- **get-mentions**: Use to fetch threads, comments, and messages that mention the current user. Prefer this over search-content when no keyword query is needed (search-content requires a non-empty query). Supports filtering by channel, author, and date range, and exposes a cursor for pagination.
 - **update-object**: Use to edit something you previously sent. Pass targetType ("thread", "comment", or "message"), targetId, and the new content. For threads you may also pass title (and may pass title without content). title is only valid for threads.
 
 ### Best Practices:

--- a/src/tools/__tests__/get-mentions.test.ts
+++ b/src/tools/__tests__/get-mentions.test.ts
@@ -1,0 +1,246 @@
+import type { TwistApi } from '@doist/twist-sdk'
+import { jest } from '@jest/globals'
+import { extractTextContent, TEST_IDS } from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { getMentions } from '../get-mentions.js'
+
+const mockTwistApi = {
+    batch: jest.fn(),
+    search: {
+        search: jest.fn(),
+    },
+    channels: {
+        getChannel: jest.fn(),
+    },
+    workspaceUsers: {
+        getUserById: jest.fn(),
+    },
+} as unknown as jest.Mocked<TwistApi>
+
+const { GET_MENTIONS } = ToolNames
+
+describe(`${GET_MENTIONS} tool`, () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockTwistApi.batch.mockImplementation(async (...args: readonly unknown[]) => {
+            const results = []
+            for (const arg of args) {
+                const result = await arg
+                results.push({ data: result })
+            }
+            return results as never
+        })
+    })
+
+    it('calls search.search with mentionSelf=true and no query', async () => {
+        mockTwistApi.search.search.mockResolvedValue({
+            items: [],
+            hasMore: false,
+            isPlanRestricted: false,
+        })
+
+        await getMentions.execute(
+            {
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                limit: 50,
+            },
+            mockTwistApi,
+        )
+
+        const call = mockTwistApi.search.search.mock.calls[0]?.[0] as Record<string, unknown>
+        expect(call).toBeDefined()
+        expect(call.mentionSelf).toBe(true)
+        expect(call.workspaceId).toBe(TEST_IDS.WORKSPACE_1)
+        expect(call.limit).toBe(50)
+        expect('query' in call).toBe(false)
+    })
+
+    it('forwards filters to search.search', async () => {
+        mockTwistApi.search.search.mockResolvedValue({
+            items: [],
+            hasMore: false,
+            isPlanRestricted: false,
+        })
+
+        await getMentions.execute(
+            {
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                channelIds: [TEST_IDS.CHANNEL_1],
+                authorIds: [TEST_IDS.USER_1],
+                dateFrom: '2024-01-01',
+                dateTo: '2024-12-31',
+                limit: 25,
+                cursor: 'cursor-abc',
+            },
+            mockTwistApi,
+        )
+
+        expect(mockTwistApi.search.search).toHaveBeenCalledWith({
+            workspaceId: TEST_IDS.WORKSPACE_1,
+            mentionSelf: true,
+            channelIds: [TEST_IDS.CHANNEL_1],
+            authorIds: [TEST_IDS.USER_1],
+            dateFrom: '2024-01-01',
+            dateTo: '2024-12-31',
+            limit: 25,
+            cursor: 'cursor-abc',
+        })
+    })
+
+    it('returns structured mentions_results with enriched names and URLs', async () => {
+        mockTwistApi.search.search.mockResolvedValue({
+            items: [
+                {
+                    id: 'thread-123',
+                    type: 'thread' as const,
+                    snippet: 'You were mentioned here',
+                    snippetCreatorId: TEST_IDS.USER_1,
+                    snippetLastUpdated: new Date('2024-01-01T00:00:00Z'),
+                    channelId: TEST_IDS.CHANNEL_1,
+                    threadId: TEST_IDS.THREAD_1,
+                    title: 'Mention thread',
+                    closed: false,
+                },
+            ],
+            hasMore: false,
+            isPlanRestricted: false,
+        })
+        mockTwistApi.workspaceUsers.getUserById.mockResolvedValue({
+            id: TEST_IDS.USER_1,
+            name: 'Test User 1',
+            shortName: 'TU1',
+            email: 'user1@test.com',
+            userType: 'USER' as const,
+            bot: false,
+            removed: false,
+            timezone: 'UTC',
+            version: 1,
+        })
+        mockTwistApi.channels.getChannel.mockResolvedValue({
+            id: TEST_IDS.CHANNEL_1,
+            name: 'Test Channel',
+            workspaceId: TEST_IDS.WORKSPACE_1,
+            created: new Date(),
+            archived: false,
+            public: true,
+            color: 0,
+            creator: TEST_IDS.USER_1,
+            version: 1,
+        })
+
+        const result = await getMentions.execute(
+            {
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                limit: 50,
+            },
+            mockTwistApi,
+        )
+
+        const { structuredContent } = result
+        expect(structuredContent).toEqual(
+            expect.objectContaining({
+                type: 'mentions_results',
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                totalResults: 1,
+                hasMore: false,
+            }),
+        )
+        expect(structuredContent?.results[0]).toEqual(
+            expect.objectContaining({
+                type: 'thread',
+                content: 'You were mentioned here',
+                creatorName: 'Test User 1',
+                channelName: 'Test Channel',
+            }),
+        )
+        expect(structuredContent?.results[0]?.url).toContain(`${TEST_IDS.THREAD_1}`)
+        expect(extractTextContent(result)).toContain('# Mentions in Workspace')
+    })
+
+    it('exposes pagination cursor when hasMore is true', async () => {
+        mockTwistApi.search.search.mockResolvedValue({
+            items: [
+                {
+                    id: 'comment-1',
+                    type: 'comment' as const,
+                    snippet: 'A mention',
+                    snippetCreatorId: TEST_IDS.USER_1,
+                    snippetLastUpdated: new Date('2024-01-01T00:00:00Z'),
+                    threadId: TEST_IDS.THREAD_1,
+                    channelId: TEST_IDS.CHANNEL_1,
+                    commentId: TEST_IDS.COMMENT_1,
+                },
+            ],
+            hasMore: true,
+            nextCursorMark: 'next-cursor-xyz',
+            isPlanRestricted: false,
+        })
+        mockTwistApi.workspaceUsers.getUserById.mockResolvedValue({
+            id: TEST_IDS.USER_1,
+            name: 'Test User 1',
+            shortName: 'TU1',
+            email: 'user1@test.com',
+            userType: 'USER' as const,
+            bot: false,
+            removed: false,
+            timezone: 'UTC',
+            version: 1,
+        })
+        mockTwistApi.channels.getChannel.mockResolvedValue({
+            id: TEST_IDS.CHANNEL_1,
+            name: 'Test Channel',
+            workspaceId: TEST_IDS.WORKSPACE_1,
+            created: new Date(),
+            archived: false,
+            public: true,
+            color: 0,
+            creator: TEST_IDS.USER_1,
+            version: 1,
+        })
+
+        const result = await getMentions.execute(
+            {
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                limit: 1,
+            },
+            mockTwistApi,
+        )
+
+        expect(result.structuredContent?.hasMore).toBe(true)
+        expect(result.structuredContent?.cursor).toBe('next-cursor-xyz')
+        expect(extractTextContent(result)).toContain('More results available')
+    })
+
+    it('handles no results found', async () => {
+        mockTwistApi.search.search.mockResolvedValue({
+            items: [],
+            hasMore: false,
+            isPlanRestricted: false,
+        })
+
+        const result = await getMentions.execute(
+            {
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                limit: 50,
+            },
+            mockTwistApi,
+        )
+
+        expect(extractTextContent(result)).toContain('No mentions found')
+        expect(result.structuredContent?.totalResults).toBe(0)
+    })
+
+    it('propagates API errors', async () => {
+        mockTwistApi.search.search.mockRejectedValue(new Error('Search API error'))
+
+        await expect(
+            getMentions.execute(
+                {
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                    limit: 50,
+                },
+                mockTwistApi,
+            ),
+        ).rejects.toThrow('Search API error')
+    })
+})

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -55,6 +55,13 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         idempotentHint: true,
     },
     {
+        name: ToolNames.GET_MENTIONS,
+        title: 'Twist: Get Mentions',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    {
         name: ToolNames.GET_USERS,
         title: 'Twist: Get Users',
         readOnlyHint: true,

--- a/src/tools/get-mentions.ts
+++ b/src/tools/get-mentions.ts
@@ -1,0 +1,231 @@
+import { type SearchResultType, getFullTwistURL } from '@doist/twist-sdk'
+import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TwistTool } from '../twist-tool.js'
+import { GetMentionsOutputSchema } from '../utils/output-schemas.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    workspaceId: z.number().describe('The workspace ID to search in.'),
+    channelIds: z.array(z.number()).optional().describe('Filter by channel IDs.'),
+    authorIds: z.array(z.number()).optional().describe('Filter by author user IDs.'),
+    dateFrom: z.string().optional().describe('Start date for filtering (YYYY-MM-DD).'),
+    dateTo: z.string().optional().describe('End date for filtering (YYYY-MM-DD).'),
+    limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .optional()
+        .default(50)
+        .describe('Maximum number of results to return.'),
+    cursor: z.string().optional().describe('Cursor for pagination.'),
+}
+
+type GetMentionsStructured = {
+    type: 'mentions_results'
+    workspaceId: number
+    results: Array<{
+        id: string
+        type: SearchResultType
+        content: string
+        creatorId: number
+        creatorName?: string
+        created: string
+        threadId?: number
+        conversationId?: number
+        channelId?: number
+        channelName?: string
+        workspaceId: number
+        url: string
+    }>
+    totalResults: number
+    hasMore: boolean
+    cursor?: string
+}
+
+const getMentions = {
+    name: ToolNames.GET_MENTIONS,
+    description:
+        'Fetch threads, comments, and messages that mention the current user. Supports filtering by channel, author, and date range. Use this instead of search-content when no keyword query is needed.',
+    parameters: ArgsSchema,
+    outputSchema: GetMentionsOutputSchema.shape,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    async execute(args, client) {
+        const { workspaceId, channelIds, authorIds, dateFrom, dateTo, limit, cursor } = args
+
+        const response = await client.search.search({
+            workspaceId,
+            mentionSelf: true,
+            channelIds,
+            authorIds,
+            dateFrom,
+            dateTo,
+            limit,
+            cursor,
+        })
+
+        const results = response.items.map((r) => ({
+            id: r.id,
+            type: r.type,
+            content: r.snippet,
+            creatorId: r.snippetCreatorId,
+            created: r.snippetLastUpdated.toISOString(),
+            threadId: r.threadId ?? undefined,
+            conversationId: r.conversationId ?? undefined,
+            channelId: r.channelId ?? undefined,
+            workspaceId,
+        }))
+
+        const hasMore = response.hasMore
+        const responseCursor = response.nextCursorMark
+
+        let userLookup: Record<number, string> = {}
+        let channelLookup: Record<number, string> = {}
+
+        if (results.length > 0) {
+            const userIds = new Set<number>()
+            const channelIds = new Set<number>()
+            for (const result of results) {
+                userIds.add(result.creatorId)
+                if (result.channelId) {
+                    channelIds.add(result.channelId)
+                }
+            }
+
+            const uniqueUserIds = Array.from(userIds)
+            const uniqueChannelIds = Array.from(channelIds)
+            const batchResponses = await client.batch(
+                ...uniqueUserIds.map((id) =>
+                    client.workspaceUsers.getUserById({ workspaceId, userId: id }, { batch: true }),
+                ),
+                ...uniqueChannelIds.map((id) => client.channels.getChannel(id, { batch: true })),
+            )
+
+            const userResponses = batchResponses.slice(0, uniqueUserIds.length)
+            const channelResponses = batchResponses.slice(uniqueUserIds.length)
+
+            const users = userResponses.map((res) => res.data)
+            userLookup = users.reduce(
+                (acc, user) => {
+                    acc[user.id] = user.name
+                    return acc
+                },
+                {} as Record<number, string>,
+            )
+
+            const channels = channelResponses.map((res) => res.data)
+            channelLookup = channels.reduce(
+                (acc, channel) => {
+                    acc[channel.id] = channel.name
+                    return acc
+                },
+                {} as Record<number, string>,
+            )
+        }
+
+        const lines: string[] = [`# Mentions in Workspace ${workspaceId}`, '']
+
+        lines.push(`**Results Found:** ${results.length}`)
+        lines.push(`**More Available:** ${hasMore ? 'Yes' : 'No'}`)
+        lines.push('')
+
+        if (results.length === 0) {
+            lines.push('_No mentions found_')
+        } else {
+            lines.push('## Results')
+            lines.push('')
+
+            for (const result of results) {
+                const date = result.created.split('T')[0]
+                const typeLabel = result.type.charAt(0).toUpperCase() + result.type.slice(1)
+                const creatorName = userLookup[result.creatorId]
+
+                lines.push(`### ${typeLabel} ${result.id}`)
+                lines.push(
+                    `**Created:** ${date} | **Creator:** ${creatorName} (${result.creatorId})`,
+                )
+
+                if (result.threadId) {
+                    lines.push(`**Thread:** ${result.threadId}`)
+                }
+                if (result.conversationId) {
+                    lines.push(`**Conversation:** ${result.conversationId}`)
+                }
+                if (result.channelId) {
+                    const channelName = channelLookup[result.channelId]
+                    lines.push(`**Channel:** ${channelName} (${result.channelId})`)
+                }
+
+                lines.push('')
+                const contentPreview =
+                    result.content.length > 200
+                        ? `${result.content.substring(0, 200)}...`
+                        : result.content
+                lines.push(contentPreview)
+                lines.push('')
+            }
+        }
+
+        if (hasMore) {
+            lines.push('## Next Steps')
+            lines.push('')
+            lines.push('More results available. Use the cursor to fetch the next page.')
+        }
+
+        const structuredContent: GetMentionsStructured = {
+            type: 'mentions_results',
+            workspaceId,
+            results: results.map((r) => {
+                let url: string
+                if (r.type === 'thread' && r.threadId !== undefined) {
+                    url = getFullTwistURL({
+                        workspaceId,
+                        threadId: r.threadId,
+                        channelId: r.channelId,
+                    })
+                } else if (
+                    r.type === 'comment' &&
+                    r.threadId !== undefined &&
+                    r.channelId !== undefined
+                ) {
+                    url = getFullTwistURL({
+                        workspaceId,
+                        threadId: r.threadId,
+                        channelId: r.channelId,
+                        commentId: r.id,
+                    })
+                } else if (r.type === 'conversation' && r.conversationId !== undefined) {
+                    url = getFullTwistURL({
+                        workspaceId,
+                        conversationId: r.conversationId,
+                    })
+                } else if (r.type === 'message' && r.conversationId !== undefined) {
+                    url = getFullTwistURL({
+                        workspaceId,
+                        conversationId: r.conversationId,
+                        messageId: r.id,
+                    })
+                } else {
+                    url = ''
+                }
+                return {
+                    ...r,
+                    creatorName: userLookup[r.creatorId],
+                    channelName: r.channelId ? channelLookup[r.channelId] : undefined,
+                    url,
+                }
+            }),
+            totalResults: results.length,
+            hasMore,
+            cursor: responseCursor,
+        }
+
+        return getToolOutput({
+            textContent: lines.join('\n'),
+            structuredContent,
+        })
+    },
+} satisfies TwistTool<typeof ArgsSchema, typeof GetMentionsOutputSchema.shape>
+
+export { getMentions, type GetMentionsStructured }

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -162,6 +162,33 @@ export const SearchContentOutputSchema = z.object({
 })
 
 /**
+ * Schema for get-mentions tool output
+ */
+export const GetMentionsOutputSchema = z.object({
+    type: z.literal('mentions_results'),
+    workspaceId: z.number(),
+    results: z.array(
+        z.object({
+            id: z.string(),
+            type: z.enum(SEARCH_RESULT_TYPES),
+            content: z.string(),
+            creatorId: z.number(),
+            creatorName: z.string().optional(),
+            created: z.string(),
+            threadId: z.number().optional(),
+            conversationId: z.number().optional(),
+            channelId: z.number().optional(),
+            channelName: z.string().optional(),
+            workspaceId: z.number(),
+            url: z.string(),
+        }),
+    ),
+    totalResults: z.number(),
+    hasMore: z.boolean(),
+    cursor: z.string().optional(),
+})
+
+/**
  * Schema for get-workspaces tool output
  */
 export const GetWorkspacesOutputSchema = z.object({

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -4,6 +4,7 @@ export const ToolNames = {
     LOAD_THREAD: 'load-thread',
     LOAD_CONVERSATION: 'load-conversation',
     SEARCH_CONTENT: 'search-content',
+    GET_MENTIONS: 'get-mentions',
     CREATE_THREAD: 'create-thread',
     UPDATE_OBJECT: 'update-object',
     REPLY: 'reply',


### PR DESCRIPTION
## Summary

- Adds a dedicated `get-mentions` MCP tool. Calls `client.search.search` with `mentionSelf: true` and no query, exposing channel/author/date/cursor filters. Closes the gap where `search-content` requires `query: z.string().min(1)`, blocking mention-only requests like \"show me everything mentioning me.\"
- Bumps `@doist/twist-sdk` to 2.5.0, which ships a discriminated `SearchArgs` union allowing `query` to be omitted when `mentionSelf: true` is set (Doist/twist-sdk-typescript#120).
- Inspired by [Doist/twist-cli#197](https://github.com/Doist/twist-cli/pull/197) which added the equivalent `tw mentions` CLI command. Out of scope from that PR: `--all` auto-pagination (token-budget risk; cursor already exposed) and the extra filters (`title`, `type`, `conversationIds`, `toUserIds`) which the SDK doesn't expose.

## Test plan

- [x] `npm test` — 170 tests pass, including 6 new `get-mentions` tests covering: `mentionSelf=true` and no-query call shape, filter forwarding, structured output enrichment (creator/channel names + URLs), pagination cursor surfacing, empty state, and error propagation. The `tool-annotations` registry guard updated to expect the new tool.
- [x] `npm run type-check` — clean.
- [x] `npm run format:check` — clean (oxlint + oxfmt).
- [ ] Manual: invoke `get-mentions` against a real workspace; verify results, filter composition, cursor round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)