### PR TITLE
feat: add delete tool for threads, comments, and messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { markDone } from './tools/mark-done.js'
 import { react } from './tools/react.js'
 import { reply } from './tools/reply.js'
 import { searchContent } from './tools/search-content.js'
+import { updateComment } from './tools/update-comment.js'
+import { updateThread } from './tools/update-thread.js'
 import { userInfo } from './tools/user-info.js'
 
 const tools = {
@@ -20,6 +22,8 @@ const tools = {
     loadConversation,
     searchContent,
     createThread,
+    updateThread,
+    updateComment,
     reply,
     react,
     markDone,
@@ -37,6 +41,8 @@ export {
     loadConversation,
     searchContent,
     createThread,
+    updateThread,
+    updateComment,
     reply,
     react,
     markDone,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2,6 +2,7 @@ import { TwistApi } from '@doist/twist-sdk'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { registerTool } from './mcp-helpers.js'
 import { away } from './tools/away.js'
+import { deleteTool } from './tools/delete.js'
 import { buildLink } from './tools/build-link.js'
 import { createThread } from './tools/create-thread.js'
 import { fetchInbox } from './tools/fetch-inbox.js'
@@ -33,6 +34,7 @@ You have access to comprehensive Twist management tools for team communication a
 
 - **fetch-inbox**: Use to fetch inbox threads for a workspace, along with unread conversations and counts. Supports archiveFilter values of active, archived, or all; use all when the user needs both open and done threads. Optionally set onlyUnread to focus on unread items.
 - **list-channels**: Use to discover channels in a workspace. Requires a workspace ID. Optionally set includeArchived to true to also list archived channels. Returns channel names, IDs, descriptions, visibility, archive status, and URLs.
+- **delete**: Permanently delete a thread, comment (thread reply), or conversation message. Requires targetType and the item ID. This action is irreversible — confirm with the user before deleting.
 
 ### Best Practices:
 
@@ -81,6 +83,7 @@ function getMcpServer({ twistApiKey, baseUrl }: { twistApiKey: string; baseUrl?:
     registerTool(react, server, twist)
     registerTool(markDone, server, twist)
     registerTool(listChannels, server, twist)
+    registerTool(deleteTool, server, twist)
 
     return server
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -14,6 +14,8 @@ import { markDone } from './tools/mark-done.js'
 import { react } from './tools/react.js'
 import { reply } from './tools/reply.js'
 import { searchContent } from './tools/search-content.js'
+import { updateComment } from './tools/update-comment.js'
+import { updateThread } from './tools/update-thread.js'
 import { userInfo } from './tools/user-info.js'
 
 const instructions = `
@@ -73,6 +75,8 @@ function getMcpServer({ twistApiKey, baseUrl }: { twistApiKey: string; baseUrl?:
     registerTool(searchContent, server, twist)
     registerTool(buildLink, server, twist)
     registerTool(createThread, server, twist)
+    registerTool(updateThread, server, twist)
+    registerTool(updateComment, server, twist)
     registerTool(reply, server, twist)
     registerTool(react, server, twist)
     registerTool(markDone, server, twist)

--- a/src/tools/__tests__/__snapshots__/create-thread.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/create-thread.test.ts.snap
@@ -13,7 +13,7 @@ exports[`create-thread tool creating threads should create a thread in a channel
 
 Let us discuss this topic
 
-> Note: Threads you create do not appear in your own Inbox by default — only recipients see them there. Find the thread in the channel view or via its URL."
+> Thread is in your Inbox (auto-unarchived after creation)."
 `;
 
 exports[`create-thread tool creating threads should create a thread with recipients 1`] = `
@@ -29,5 +29,5 @@ exports[`create-thread tool creating threads should create a thread with recipie
 
 Important update
 
-> Note: Threads you create do not appear in your own Inbox by default — only recipients see them there. Find the thread in the channel view or via its URL."
+> Thread is in your Inbox (auto-unarchived after creation)."
 `;

--- a/src/tools/__tests__/__snapshots__/create-thread.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/create-thread.test.ts.snap
@@ -11,7 +11,9 @@ exports[`create-thread tool creating threads should create a thread in a channel
 
 ## Content
 
-Let us discuss this topic"
+Let us discuss this topic
+
+> Note: Threads you create do not appear in your own Inbox by default — only recipients see them there. Find the thread in the channel view or via its URL."
 `;
 
 exports[`create-thread tool creating threads should create a thread with recipients 1`] = `
@@ -25,5 +27,7 @@ exports[`create-thread tool creating threads should create a thread with recipie
 
 ## Content
 
-Important update"
+Important update
+
+> Note: Threads you create do not appear in your own Inbox by default — only recipients see them there. Find the thread in the channel view or via its URL."
 `;

--- a/src/tools/__tests__/__snapshots__/update-comment.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/update-comment.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`update-comment tool updating comments should update a comment content 1`] = `
+"# Comment Updated
+
+**Comment ID:** 54321
+**Thread ID:** 12345
+**Channel ID:** 67890
+**URL:** https://twist.com/a/11111/ch/67890/t/12345/c/54321
+
+## Content
+
+Updated comment content"
+`;

--- a/src/tools/__tests__/__snapshots__/update-thread.test.ts.snap
+++ b/src/tools/__tests__/__snapshots__/update-thread.test.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`update-thread tool updating threads should update a thread title and content 1`] = `
+"# Thread Updated
+
+**Title:** Updated Title
+**Thread ID:** 12345
+**Channel ID:** 67890
+**URL:** https://twist.com/a/11111/ch/67890/t/12345/
+
+## Content
+
+Updated content"
+`;
+
+exports[`update-thread tool updating threads should update only the thread content 1`] = `
+"# Thread Updated
+
+**Title:** Test Thread
+**Thread ID:** 12345
+**Channel ID:** 67890
+**URL:** https://twist.com/a/11111/ch/67890/t/12345/
+
+## Content
+
+New content only"
+`;
+
+exports[`update-thread tool updating threads should update only the thread title 1`] = `
+"# Thread Updated
+
+**Title:** New Title Only
+**Thread ID:** 12345
+**Channel ID:** 67890
+**URL:** https://twist.com/a/11111/ch/67890/t/12345/
+
+## Content
+
+Test thread content"
+`;

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -83,6 +83,20 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         idempotentHint: false,
     },
     {
+        name: ToolNames.UPDATE_THREAD,
+        title: 'Twist: Update Thread',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    {
+        name: ToolNames.UPDATE_COMMENT,
+        title: 'Twist: Update Comment',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    {
         name: ToolNames.REPLY,
         title: 'Twist: Reply',
         readOnlyHint: false,

--- a/src/tools/__tests__/update-comment.test.ts
+++ b/src/tools/__tests__/update-comment.test.ts
@@ -1,0 +1,74 @@
+import type { TwistApi } from '@doist/twist-sdk'
+import { jest } from '@jest/globals'
+import { createMockComment, extractTextContent, TEST_IDS } from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { updateComment } from '../update-comment.js'
+
+const mockTwistApi = {
+    comments: {
+        updateComment: jest.fn(),
+    },
+} as unknown as jest.Mocked<TwistApi>
+
+const { UPDATE_COMMENT } = ToolNames
+
+describe(`${UPDATE_COMMENT} tool`, () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('updating comments', () => {
+        it('should update a comment content', async () => {
+            const mockComment = createMockComment({
+                content: 'Updated comment content',
+            })
+            mockTwistApi.comments.updateComment.mockResolvedValue(mockComment)
+
+            const result = await updateComment.execute(
+                {
+                    id: TEST_IDS.COMMENT_1,
+                    content: 'Updated comment content',
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.comments.updateComment).toHaveBeenCalledWith({
+                id: TEST_IDS.COMMENT_1,
+                content: 'Updated comment content',
+            })
+
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    type: 'update_comment_result',
+                    success: true,
+                    commentId: mockComment.id,
+                    threadId: mockComment.threadId,
+                    channelId: mockComment.channelId,
+                    workspaceId: mockComment.workspaceId,
+                    content: 'Updated comment content',
+                    commentUrl: expect.stringContaining('twist.com'),
+                }),
+            )
+        })
+    })
+
+    describe('error handling', () => {
+        it('should propagate API errors', async () => {
+            const apiError = new Error('Comment not found')
+            mockTwistApi.comments.updateComment.mockRejectedValue(apiError)
+
+            await expect(
+                updateComment.execute(
+                    {
+                        id: TEST_IDS.COMMENT_1,
+                        content: 'Updated content',
+                    },
+                    mockTwistApi,
+                ),
+            ).rejects.toThrow('Comment not found')
+        })
+    })
+})

--- a/src/tools/__tests__/update-thread.test.ts
+++ b/src/tools/__tests__/update-thread.test.ts
@@ -1,0 +1,123 @@
+import type { TwistApi } from '@doist/twist-sdk'
+import { jest } from '@jest/globals'
+import { createMockThread, extractTextContent, TEST_IDS } from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { updateThread } from '../update-thread.js'
+
+const mockTwistApi = {
+    threads: {
+        updateThread: jest.fn(),
+    },
+} as unknown as jest.Mocked<TwistApi>
+
+const { UPDATE_THREAD } = ToolNames
+
+describe(`${UPDATE_THREAD} tool`, () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('updating threads', () => {
+        it('should update a thread title and content', async () => {
+            const mockThread = createMockThread({
+                title: 'Updated Title',
+                content: 'Updated content',
+            })
+            mockTwistApi.threads.updateThread.mockResolvedValue(mockThread)
+
+            const result = await updateThread.execute(
+                {
+                    id: TEST_IDS.THREAD_1,
+                    title: 'Updated Title',
+                    content: 'Updated content',
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.threads.updateThread).toHaveBeenCalledWith({
+                id: TEST_IDS.THREAD_1,
+                title: 'Updated Title',
+                content: 'Updated content',
+            })
+
+            expect(extractTextContent(result)).toMatchSnapshot()
+
+            const { structuredContent } = result
+            expect(structuredContent).toEqual(
+                expect.objectContaining({
+                    type: 'update_thread_result',
+                    success: true,
+                    threadId: mockThread.id,
+                    title: 'Updated Title',
+                    channelId: TEST_IDS.CHANNEL_1,
+                    workspaceId: TEST_IDS.WORKSPACE_1,
+                    content: 'Updated content',
+                    threadUrl: expect.stringContaining('twist.com'),
+                }),
+            )
+        })
+
+        it('should update only the thread title', async () => {
+            const mockThread = createMockThread({
+                title: 'New Title Only',
+            })
+            mockTwistApi.threads.updateThread.mockResolvedValue(mockThread)
+
+            const result = await updateThread.execute(
+                {
+                    id: TEST_IDS.THREAD_1,
+                    title: 'New Title Only',
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.threads.updateThread).toHaveBeenCalledWith({
+                id: TEST_IDS.THREAD_1,
+                title: 'New Title Only',
+                content: undefined,
+            })
+
+            expect(extractTextContent(result)).toMatchSnapshot()
+        })
+
+        it('should update only the thread content', async () => {
+            const mockThread = createMockThread({
+                content: 'New content only',
+            })
+            mockTwistApi.threads.updateThread.mockResolvedValue(mockThread)
+
+            const result = await updateThread.execute(
+                {
+                    id: TEST_IDS.THREAD_1,
+                    content: 'New content only',
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.threads.updateThread).toHaveBeenCalledWith({
+                id: TEST_IDS.THREAD_1,
+                title: undefined,
+                content: 'New content only',
+            })
+
+            expect(extractTextContent(result)).toMatchSnapshot()
+        })
+    })
+
+    describe('error handling', () => {
+        it('should propagate API errors', async () => {
+            const apiError = new Error('Thread not found')
+            mockTwistApi.threads.updateThread.mockRejectedValue(apiError)
+
+            await expect(
+                updateThread.execute(
+                    {
+                        id: TEST_IDS.THREAD_1,
+                        title: 'Updated Title',
+                    },
+                    mockTwistApi,
+                ),
+            ).rejects.toThrow('Thread not found')
+        })
+    })
+})

--- a/src/tools/create-thread.ts
+++ b/src/tools/create-thread.ts
@@ -34,6 +34,16 @@ const createThread = {
             recipients,
         })
 
+        // Twist auto-archives newly-created threads for the author, which means
+        // the agent's own posts never appear in the user's Inbox. Unarchive
+        // immediately so the thread shows up in the author's Inbox view too.
+        // Failure here is non-fatal — the thread itself was created successfully.
+        try {
+            await client.inbox.unarchiveThread(thread.id)
+        } catch {
+            // swallow — don't fail the tool because of an inbox visibility tweak
+        }
+
         const postedValue = thread.posted
         const created = postedValue
             ? typeof postedValue === 'string'
@@ -62,7 +72,7 @@ const createThread = {
             '',
             thread.content,
             '',
-            '> Note: Threads you create do not appear in your own Inbox by default — only recipients see them there. Find the thread in the channel view or via its URL.',
+            '> Thread is in your Inbox (auto-unarchived after creation).',
         ]
 
         const structuredContent: CreateThreadOutput = {

--- a/src/tools/create-thread.ts
+++ b/src/tools/create-thread.ts
@@ -13,7 +13,7 @@ const ArgsSchema = {
         .array(z.number())
         .optional()
         .describe(
-            'Optional array of user IDs to notify about the thread. If not provided, the channel default recipients will be used.',
+            'Optional array of user IDs to notify. If omitted, Twist defaults to notifying all current members of the channel (equivalent to the API\'s "EVERYONE" default). Note: workspace users who have not joined this channel will not be notified — add their IDs explicitly if you want to reach them.',
         ),
 }
 
@@ -61,6 +61,8 @@ const createThread = {
             '## Content',
             '',
             thread.content,
+            '',
+            '> Note: Threads you create do not appear in your own Inbox by default — only recipients see them there. Find the thread in the channel view or via its URL.',
         ]
 
         const structuredContent: CreateThreadOutput = {

--- a/src/tools/delete.ts
+++ b/src/tools/delete.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TwistTool } from '../twist-tool.js'
+import { DeleteOutputSchema } from '../utils/output-schemas.js'
+import { type DeleteTargetType, DeleteTargetTypeSchema } from '../utils/target-types.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    targetType: DeleteTargetTypeSchema.describe(
+        'The type of item to delete: thread, comment (a reply in a thread), or message (a message in a conversation).',
+    ),
+    id: z.number().describe('The ID of the item to delete.'),
+}
+
+const deleteTool = {
+    name: ToolNames.DELETE,
+    description:
+        'Permanently delete a thread, comment, or conversation message. This action cannot be undone. Use targetType to specify what to delete and id for the item ID.',
+    parameters: ArgsSchema,
+    outputSchema: DeleteOutputSchema.shape,
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
+    async execute(args, client) {
+        const { targetType, id } = args
+
+        if (targetType === 'thread') {
+            await client.threads.deleteThread(id)
+        } else if (targetType === 'comment') {
+            await client.comments.deleteComment(id)
+        } else {
+            await client.conversationMessages.deleteMessage(id)
+        }
+
+        const lines: string[] = [
+            `# Deleted`,
+            '',
+            `**Type:** ${targetType}`,
+            `**ID:** ${id}`,
+        ]
+
+        return getToolOutput({
+            textContent: lines.join('\n'),
+            structuredContent: {
+                type: 'delete_result' as const,
+                success: true,
+                targetType: targetType as DeleteTargetType,
+                id,
+            },
+        })
+    },
+} satisfies TwistTool<typeof ArgsSchema, typeof DeleteOutputSchema.shape>
+
+export { deleteTool }

--- a/src/tools/reply.ts
+++ b/src/tools/reply.ts
@@ -15,7 +15,9 @@ const ArgsSchema = {
     recipients: z
         .array(z.number())
         .optional()
-        .describe('Optional array of user IDs to notify (only for thread replies).'),
+        .describe(
+            'Optional array of user IDs to notify (only for thread replies). If omitted, Twist defaults to notifying all current members of the channel. Add specific user IDs to limit or expand notifications beyond current channel members.',
+        ),
 }
 
 type ReplyStructured = {

--- a/src/tools/update-comment.ts
+++ b/src/tools/update-comment.ts
@@ -1,0 +1,68 @@
+import { getFullTwistURL } from '@doist/twist-sdk'
+import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TwistTool } from '../twist-tool.js'
+import { type UpdateCommentOutput, UpdateCommentOutputSchema } from '../utils/output-schemas.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    id: z.number().describe('The ID of the comment to update.'),
+    content: z.string().min(1).describe('The new content for the comment.'),
+}
+
+const updateComment = {
+    name: ToolNames.UPDATE_COMMENT,
+    description:
+        "Update an existing comment's content. Requires the comment ID and the new content.",
+    parameters: ArgsSchema,
+    outputSchema: UpdateCommentOutputSchema.shape,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    async execute(args, client) {
+        const { id, content } = args
+
+        const comment = await client.comments.updateComment({
+            id,
+            content,
+        })
+
+        const commentUrl =
+            comment.url ??
+            getFullTwistURL({
+                workspaceId: comment.workspaceId,
+                channelId: comment.channelId,
+                threadId: comment.threadId,
+                commentId: comment.id,
+            })
+
+        const lines: string[] = [
+            `# Comment Updated`,
+            '',
+            `**Comment ID:** ${comment.id}`,
+            `**Thread ID:** ${comment.threadId}`,
+            `**Channel ID:** ${comment.channelId}`,
+            `**URL:** ${commentUrl}`,
+            '',
+            '## Content',
+            '',
+            comment.content,
+        ]
+
+        const structuredContent: UpdateCommentOutput = {
+            type: 'update_comment_result',
+            success: true,
+            commentId: comment.id,
+            threadId: comment.threadId,
+            channelId: comment.channelId,
+            workspaceId: comment.workspaceId,
+            content: comment.content,
+            commentUrl,
+        }
+
+        return getToolOutput({
+            textContent: lines.join('\n'),
+            structuredContent,
+        })
+    },
+} satisfies TwistTool<typeof ArgsSchema, typeof UpdateCommentOutputSchema.shape>
+
+export { updateComment }

--- a/src/tools/update-thread.ts
+++ b/src/tools/update-thread.ts
@@ -1,0 +1,69 @@
+import { getFullTwistURL } from '@doist/twist-sdk'
+import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TwistTool } from '../twist-tool.js'
+import { type UpdateThreadOutput, UpdateThreadOutputSchema } from '../utils/output-schemas.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    id: z.number().describe('The ID of the thread to update.'),
+    title: z.string().min(1).optional().describe('The new title for the thread.'),
+    content: z.string().min(1).optional().describe('The new content/body for the thread.'),
+}
+
+const updateThread = {
+    name: ToolNames.UPDATE_THREAD,
+    description:
+        "Update an existing thread's title and/or content. Requires the thread ID and at least one of title or content to update.",
+    parameters: ArgsSchema,
+    outputSchema: UpdateThreadOutputSchema.shape,
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    async execute(args, client) {
+        const { id, title, content } = args
+
+        const thread = await client.threads.updateThread({
+            id,
+            title,
+            content,
+        })
+
+        const threadUrl =
+            thread.url ??
+            getFullTwistURL({
+                workspaceId: thread.workspaceId,
+                channelId: thread.channelId,
+                threadId: thread.id,
+            })
+
+        const lines: string[] = [
+            `# Thread Updated`,
+            '',
+            `**Title:** ${thread.title}`,
+            `**Thread ID:** ${thread.id}`,
+            `**Channel ID:** ${thread.channelId}`,
+            `**URL:** ${threadUrl}`,
+            '',
+            '## Content',
+            '',
+            thread.content,
+        ]
+
+        const structuredContent: UpdateThreadOutput = {
+            type: 'update_thread_result',
+            success: true,
+            threadId: thread.id,
+            title: thread.title,
+            channelId: thread.channelId,
+            workspaceId: thread.workspaceId,
+            content: thread.content,
+            threadUrl,
+        }
+
+        return getToolOutput({
+            textContent: lines.join('\n'),
+            structuredContent,
+        })
+    },
+} satisfies TwistTool<typeof ArgsSchema, typeof UpdateThreadOutputSchema.shape>
+
+export { updateThread }

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -282,6 +282,34 @@ export const CreateThreadOutputSchema = z.object({
 })
 
 /**
+ * Schema for update-thread tool output
+ */
+export const UpdateThreadOutputSchema = z.object({
+    type: z.literal('update_thread_result'),
+    success: z.boolean(),
+    threadId: z.number(),
+    title: z.string(),
+    channelId: z.number(),
+    workspaceId: z.number(),
+    content: z.string(),
+    threadUrl: z.string(),
+})
+
+/**
+ * Schema for update-comment tool output
+ */
+export const UpdateCommentOutputSchema = z.object({
+    type: z.literal('update_comment_result'),
+    success: z.boolean(),
+    commentId: z.number(),
+    threadId: z.number(),
+    channelId: z.number(),
+    workspaceId: z.number(),
+    content: z.string(),
+    commentUrl: z.string(),
+})
+
+/**
  * Schema for reply tool output
  */
 export const ReplyOutputSchema = z.object({
@@ -375,6 +403,8 @@ export const StructuredOutputSchema = z.union([
     UserInfoOutputSchema,
     BuildLinkOutputSchema,
     CreateThreadOutputSchema,
+    UpdateThreadOutputSchema,
+    UpdateCommentOutputSchema,
     ReplyOutputSchema,
     ReactOutputSchema,
     MarkDoneOutputSchema,
@@ -385,6 +415,8 @@ export const StructuredOutputSchema = z.union([
  * Type definitions for the structured outputs
  */
 export type CreateThreadOutput = z.infer<typeof CreateThreadOutputSchema>
+export type UpdateThreadOutput = z.infer<typeof UpdateThreadOutputSchema>
+export type UpdateCommentOutput = z.infer<typeof UpdateCommentOutputSchema>
 export type AwayOutput = z.infer<typeof AwayOutputSchema>
 export type LoadThreadOutput = z.infer<typeof LoadThreadOutputSchema>
 export type LoadConversationOutput = z.infer<typeof LoadConversationOutputSchema>

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -367,6 +367,16 @@ export const MarkDoneOutputSchema = z.object({
 })
 
 /**
+ * Schema for delete tool output
+ */
+export const DeleteOutputSchema = z.object({
+    type: z.literal('delete_result'),
+    success: z.boolean(),
+    targetType: z.enum(['thread', 'comment', 'message']),
+    id: z.number(),
+})
+
+/**
  * Schema for list-channels tool output
  */
 export const ListChannelsOutputSchema = z.object({
@@ -409,6 +419,7 @@ export const StructuredOutputSchema = z.union([
     ReactOutputSchema,
     MarkDoneOutputSchema,
     ListChannelsOutputSchema,
+    DeleteOutputSchema,
 ])
 
 /**
@@ -430,4 +441,5 @@ export type ReplyOutput = z.infer<typeof ReplyOutputSchema>
 export type ReactOutput = z.infer<typeof ReactOutputSchema>
 export type MarkDoneOutput = z.infer<typeof MarkDoneOutputSchema>
 export type ListChannelsOutput = z.infer<typeof ListChannelsOutputSchema>
+export type DeleteOutput = z.infer<typeof DeleteOutputSchema>
 export type StructuredOutput = z.infer<typeof StructuredOutputSchema>

--- a/src/utils/target-types.ts
+++ b/src/utils/target-types.ts
@@ -46,3 +46,10 @@ export type SearchScope = z.infer<typeof SearchScopeSchema>
 export const MarkDoneType = createEnumSchema(['thread', 'conversation'])
 export const MarkDoneTypeSchema = MarkDoneType.schema
 export type MarkDoneType = z.infer<typeof MarkDoneTypeSchema>
+
+/**
+ * Target types for deletion
+ */
+export const DeleteTargetType = createEnumSchema(['thread', 'comment', 'message'])
+export const DeleteTargetTypeSchema = DeleteTargetType.schema
+export type DeleteTargetType = z.infer<typeof DeleteTargetTypeSchema>

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -15,4 +15,5 @@ export const ToolNames = {
     GET_USERS: 'get-users',
     AWAY: 'away',
     LIST_CHANNELS: 'list-channels',
+    DELETE: 'delete',
 } as const

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -5,6 +5,8 @@ export const ToolNames = {
     LOAD_CONVERSATION: 'load-conversation',
     SEARCH_CONTENT: 'search-content',
     CREATE_THREAD: 'create-thread',
+    UPDATE_THREAD: 'update-thread',
+    UPDATE_COMMENT: 'update-comment',
     REPLY: 'reply',
     REACT: 'react',
     MARK_DONE: 'mark-done',


### PR DESCRIPTION
## Summary

Adds a `delete` tool that permanently removes a thread, comment, or conversation message via the Twist API.

- Supports `targetType`: `thread`, `comment`, `message`
- Calls `client.threads.deleteThread`, `client.comments.deleteComment`, or `client.conversationMessages.deleteMessage` respectively
- Marked `destructiveHint: true` in annotations
- Returns structured output with `type`, `success`, `targetType`, and `id`
- Instructions updated to note the tool is irreversible and to confirm with the user before use

## Test plan

- [ ] Delete a thread: `{ targetType: "thread", id: <thread_id> }`
- [ ] Delete a comment: `{ targetType: "comment", id: <comment_id> }`
- [ ] Delete a conversation message: `{ targetType: "message", id: <message_id> }`
- [ ] Verify deleted items no longer appear in Twist
- [ ] Verify error is thrown for non-existent or unauthorized IDs