### PR TITLE
feat: add Twist group recipients support

### DIFF
--- a/scripts/run-tool.ts
+++ b/scripts/run-tool.ts
@@ -21,6 +21,7 @@ import { away } from '../src/tools/away.js'
 import { buildLink } from '../src/tools/build-link.js'
 import { createThread } from '../src/tools/create-thread.js'
 import { fetchInbox } from '../src/tools/fetch-inbox.js'
+import { getGroups } from '../src/tools/get-groups.js'
 import { getMentions } from '../src/tools/get-mentions.js'
 import { getUsers } from '../src/tools/get-users.js'
 import { getWorkspaces } from '../src/tools/get-workspaces.js'
@@ -63,6 +64,7 @@ const tools: Record<string, ExecutableTool> = {
     'build-link': buildLink,
     'get-workspaces': getWorkspaces,
     'get-users': getUsers,
+    'get-groups': getGroups,
     away: away,
     'list-channels': listChannels,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { away } from './tools/away.js'
 import { buildLink } from './tools/build-link.js'
 import { createThread } from './tools/create-thread.js'
 import { fetchInbox } from './tools/fetch-inbox.js'
+import { getGroups } from './tools/get-groups.js'
 import { getMentions } from './tools/get-mentions.js'
 import { listChannels } from './tools/list-channels.js'
 import { loadConversation } from './tools/load-conversation.js'
@@ -29,6 +30,7 @@ const tools = {
     markDone,
     buildLink,
     listChannels,
+    getGroups,
 }
 
 export { tools, getMcpServer }
@@ -48,4 +50,5 @@ export {
     markDone,
     buildLink,
     listChannels,
+    getGroups,
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -36,7 +36,7 @@ You have access to comprehensive Twist management tools for team communication a
 - **list-channels**: Use to discover channels in a workspace. Requires a workspace ID. Optionally set includeArchived to true to also list archived channels. Returns channel names, IDs, descriptions, visibility, archive status, and URLs.
 - **get-groups**: Use to discover group IDs in a workspace before notifying groups from tools that support group notifications. Requires a workspace ID. Optionally filter by group IDs or search text.
 - **create-thread**: Use to create a new channel thread. Optionally pass recipients for user IDs and groups for group IDs; call get-users or get-groups first when resolving names.
-- **reply**: Use to reply to a thread or conversation. Thread replies can optionally pass recipients for user IDs and groups for group IDs; group notifications do not apply to conversation replies.
+- **reply**: Use to reply to a thread or conversation. Thread replies notify everyone who has interacted with the thread by default. Optionally pass recipients for user IDs or groups for group IDs to override that default; group notifications do not apply to conversation replies.
 - **get-mentions**: Use to fetch threads, comments, and messages that mention the current user. Prefer this over search-content when no keyword query is needed (search-content requires a non-empty query). Supports filtering by channel, author, and date range, and exposes a cursor for pagination.
 - **update-object**: Use to edit something you previously sent. Pass targetType ("thread", "comment", or "message"), targetId, and the new content. For threads you may also pass title (and may pass title without content). title is only valid for threads.
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -34,9 +34,9 @@ You have access to comprehensive Twist management tools for team communication a
 
 - **fetch-inbox**: Use to fetch inbox threads for a workspace, along with unread conversations and counts. Supports archiveFilter values of active, archived, or all; use all when the user needs both open and done threads. Optionally set onlyUnread to focus on unread items.
 - **list-channels**: Use to discover channels in a workspace. Requires a workspace ID. Optionally set includeArchived to true to also list archived channels. Returns channel names, IDs, descriptions, visibility, archive status, and URLs.
-- **get-groups**: Use to discover group IDs in a workspace before notifying groups from tools that support group notifications. Requires a workspace ID. Optionally filter by group IDs or search text.
+- **get-groups**: Use to discover group IDs in a workspace before notifying groups from tools that support group notifications. Requires a workspace ID. Optionally filter by group IDs or search text. Returns group IDs, names, and member counts without member lists or descriptions.
 - **create-thread**: Use to create a new channel thread. Optionally pass recipients for user IDs and groups for group IDs; call get-users or get-groups first when resolving names.
-- **reply**: Use to reply to a thread or conversation. Thread replies notify everyone who has interacted with the thread by default. Optionally pass recipients for user IDs or groups for group IDs to override that default; group notifications do not apply to conversation replies.
+- **reply**: Use to reply to a thread or conversation. Thread replies notify everyone who has interacted with the thread by default. Optionally pass recipients for user IDs or groups for group IDs to override that default. Passing groups to a conversation reply is rejected.
 - **get-mentions**: Use to fetch threads, comments, and messages that mention the current user. Prefer this over search-content when no keyword query is needed (search-content requires a non-empty query). Supports filtering by channel, author, and date range, and exposes a cursor for pagination.
 - **update-object**: Use to edit something you previously sent. Pass targetType ("thread", "comment", or "message"), targetId, and the new content. For threads you may also pass title (and may pass title without content). title is only valid for threads.
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -5,6 +5,7 @@ import { away } from './tools/away.js'
 import { buildLink } from './tools/build-link.js'
 import { createThread } from './tools/create-thread.js'
 import { fetchInbox } from './tools/fetch-inbox.js'
+import { getGroups } from './tools/get-groups.js'
 import { getMentions } from './tools/get-mentions.js'
 import { getUsers } from './tools/get-users.js'
 import { getWorkspaces } from './tools/get-workspaces.js'
@@ -33,6 +34,9 @@ You have access to comprehensive Twist management tools for team communication a
 
 - **fetch-inbox**: Use to fetch inbox threads for a workspace, along with unread conversations and counts. Supports archiveFilter values of active, archived, or all; use all when the user needs both open and done threads. Optionally set onlyUnread to focus on unread items.
 - **list-channels**: Use to discover channels in a workspace. Requires a workspace ID. Optionally set includeArchived to true to also list archived channels. Returns channel names, IDs, descriptions, visibility, archive status, and URLs.
+- **get-groups**: Use to discover group IDs in a workspace before notifying groups from tools that support group notifications. Requires a workspace ID. Optionally filter by group IDs or search text.
+- **create-thread**: Use to create a new channel thread. Optionally pass recipients for user IDs and groups for group IDs; call get-users or get-groups first when resolving names.
+- **reply**: Use to reply to a thread or conversation. Thread replies can optionally pass recipients for user IDs and groups for group IDs; group notifications do not apply to conversation replies.
 - **get-mentions**: Use to fetch threads, comments, and messages that mention the current user. Prefer this over search-content when no keyword query is needed (search-content requires a non-empty query). Supports filtering by channel, author, and date range, and exposes a cursor for pagination.
 - **update-object**: Use to edit something you previously sent. Pass targetType ("thread", "comment", or "message"), targetId, and the new content. For threads you may also pass title (and may pass title without content). title is only valid for threads.
 
@@ -71,6 +75,7 @@ function getMcpServer({ twistApiKey, baseUrl }: { twistApiKey: string; baseUrl?:
     registerTool(away, server, twist)
     registerTool(getWorkspaces, server, twist)
     registerTool(getUsers, server, twist)
+    registerTool(getGroups, server, twist)
     registerTool(fetchInbox, server, twist)
     registerTool(loadThread, server, twist)
     registerTool(loadConversation, server, twist)

--- a/src/tools/__tests__/create-thread.test.ts
+++ b/src/tools/__tests__/create-thread.test.ts
@@ -126,6 +126,36 @@ describe(`${CREATE_THREAD} tool`, () => {
             expect(structuredContent).not.toHaveProperty('recipients')
         })
 
+        it('should preserve empty groups when creating a thread', async () => {
+            const mockThread = createMockThread({
+                title: 'Empty Groups',
+                content: 'No group recipients',
+            })
+            mockTwistApi.threads.createThread.mockResolvedValue(mockThread)
+
+            const result = await createThread.execute(
+                {
+                    channelId: TEST_IDS.CHANNEL_1,
+                    title: 'Empty Groups',
+                    content: 'No group recipients',
+                    groups: [],
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.threads.createThread).toHaveBeenCalledWith({
+                channelId: TEST_IDS.CHANNEL_1,
+                title: 'Empty Groups',
+                content: 'No group recipients',
+                recipients: undefined,
+                groups: [],
+            })
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.groups).toEqual([])
+            expect(structuredContent).not.toHaveProperty('recipients')
+        })
+
         it('should create a thread with recipients and groups', async () => {
             const mockThread = createMockThread({
                 title: 'Notify Users and Groups',

--- a/src/tools/__tests__/create-thread.test.ts
+++ b/src/tools/__tests__/create-thread.test.ts
@@ -1,6 +1,11 @@
 import type { TwistApi } from '@doist/twist-sdk'
 import { jest } from '@jest/globals'
-import { createMockThread, extractTextContent, TEST_IDS } from '../../utils/test-helpers.js'
+import {
+    createMockThread,
+    extractStructuredContent,
+    extractTextContent,
+    TEST_IDS,
+} from '../../utils/test-helpers.js'
 import { ToolNames } from '../../utils/tool-names.js'
 import { createThread } from '../create-thread.js'
 
@@ -39,6 +44,7 @@ describe(`${CREATE_THREAD} tool`, () => {
                 title: 'New Discussion',
                 content: 'Let us discuss this topic',
                 recipients: undefined,
+                groups: undefined,
             })
 
             expect(extractTextContent(result)).toMatchSnapshot()
@@ -80,9 +86,75 @@ describe(`${CREATE_THREAD} tool`, () => {
                 title: 'Notify Users',
                 content: 'Important update',
                 recipients: [TEST_IDS.USER_1, TEST_IDS.USER_2],
+                groups: undefined,
             })
 
             expect(extractTextContent(result)).toMatchSnapshot()
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.recipients).toEqual([TEST_IDS.USER_1, TEST_IDS.USER_2])
+            expect(structuredContent).not.toHaveProperty('groups')
+        })
+
+        it('should create a thread with groups', async () => {
+            const mockThread = createMockThread({
+                title: 'Notify Groups',
+                content: 'Important group update',
+            })
+            mockTwistApi.threads.createThread.mockResolvedValue(mockThread)
+
+            const result = await createThread.execute(
+                {
+                    channelId: TEST_IDS.CHANNEL_1,
+                    title: 'Notify Groups',
+                    content: 'Important group update',
+                    groups: [100, 200],
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.threads.createThread).toHaveBeenCalledWith({
+                channelId: TEST_IDS.CHANNEL_1,
+                title: 'Notify Groups',
+                content: 'Important group update',
+                recipients: undefined,
+                groups: [100, 200],
+            })
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.groups).toEqual([100, 200])
+            expect(structuredContent).not.toHaveProperty('recipients')
+        })
+
+        it('should create a thread with recipients and groups', async () => {
+            const mockThread = createMockThread({
+                title: 'Notify Users and Groups',
+                content: 'Important broad update',
+            })
+            mockTwistApi.threads.createThread.mockResolvedValue(mockThread)
+
+            const result = await createThread.execute(
+                {
+                    channelId: TEST_IDS.CHANNEL_1,
+                    title: 'Notify Users and Groups',
+                    content: 'Important broad update',
+                    recipients: [TEST_IDS.USER_1],
+                    groups: [100],
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.threads.createThread).toHaveBeenCalledWith({
+                channelId: TEST_IDS.CHANNEL_1,
+                title: 'Notify Users and Groups',
+                content: 'Important broad update',
+                recipients: [TEST_IDS.USER_1],
+                groups: [100],
+            })
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.recipients).toEqual([TEST_IDS.USER_1])
+            expect(structuredContent.groups).toEqual([100])
         })
     })
 

--- a/src/tools/__tests__/get-groups.test.ts
+++ b/src/tools/__tests__/get-groups.test.ts
@@ -59,6 +59,7 @@ describe(`${GET_GROUPS} tool`, () => {
             expect(textContent).toContain('## Product Automation')
             expect(textContent).toContain('## Engineering')
             expect(textContent).toContain('**Members:** 2')
+            expect(textContent).not.toContain('Automation recipients')
 
             const structuredContent = extractStructuredContent(result)
             expect(structuredContent).toEqual({
@@ -70,18 +71,17 @@ describe(`${GET_GROUPS} tool`, () => {
                     expect.objectContaining({
                         id: 100,
                         name: 'Product Automation',
-                        description: 'Automation recipients',
-                        userIds: [TEST_IDS.USER_1, TEST_IDS.USER_2],
                         memberCount: 2,
                     }),
                     expect.objectContaining({
                         id: 200,
                         name: 'Engineering',
-                        userIds: [TEST_IDS.USER_3],
                         memberCount: 1,
                     }),
                 ]),
             })
+            expect(structuredContent.groups[0]).not.toHaveProperty('description')
+            expect(structuredContent.groups[0]).not.toHaveProperty('userIds')
         })
 
         it('should handle empty groupIds array by fetching all groups', async () => {

--- a/src/tools/__tests__/get-groups.test.ts
+++ b/src/tools/__tests__/get-groups.test.ts
@@ -1,0 +1,225 @@
+import type { Group, TwistApi } from '@doist/twist-sdk'
+import { jest } from '@jest/globals'
+import {
+    extractStructuredContent,
+    extractTextContent,
+    TEST_ERRORS,
+    TEST_IDS,
+} from '../../utils/test-helpers.js'
+import { ToolNames } from '../../utils/tool-names.js'
+import { getGroups } from '../get-groups.js'
+
+const mockTwistApi = {
+    groups: {
+        getGroups: jest.fn(),
+    },
+} as unknown as jest.Mocked<TwistApi>
+
+const { GET_GROUPS } = ToolNames
+
+const createMockGroup = (overrides: Partial<Group> = {}): Group => ({
+    id: 100,
+    name: 'Product Automation',
+    description: 'Automation recipients',
+    workspaceId: TEST_IDS.WORKSPACE_1,
+    userIds: [TEST_IDS.USER_1, TEST_IDS.USER_2],
+    version: 1,
+    ...overrides,
+})
+
+describe(`${GET_GROUPS} tool`, () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe('fetching groups', () => {
+        it('should fetch all workspace groups by default', async () => {
+            const mockGroups = [
+                createMockGroup(),
+                createMockGroup({
+                    id: 200,
+                    name: 'Engineering',
+                    description: null,
+                    userIds: [TEST_IDS.USER_3],
+                }),
+            ]
+
+            mockTwistApi.groups.getGroups.mockResolvedValue(mockGroups)
+
+            const result = await getGroups.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1 },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.groups.getGroups).toHaveBeenCalledWith(TEST_IDS.WORKSPACE_1)
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain(`**Workspace ID:** ${TEST_IDS.WORKSPACE_1}`)
+            expect(textContent).toContain('**Total Groups:** 2')
+            expect(textContent).toContain('## Product Automation')
+            expect(textContent).toContain('## Engineering')
+            expect(textContent).toContain('**Members:** 2')
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).toEqual({
+                type: 'get_groups',
+                workspaceId: TEST_IDS.WORKSPACE_1,
+                totalGroups: 2,
+                filteredGroups: 2,
+                groups: expect.arrayContaining([
+                    expect.objectContaining({
+                        id: 100,
+                        name: 'Product Automation',
+                        description: 'Automation recipients',
+                        userIds: [TEST_IDS.USER_1, TEST_IDS.USER_2],
+                        memberCount: 2,
+                    }),
+                    expect.objectContaining({
+                        id: 200,
+                        name: 'Engineering',
+                        userIds: [TEST_IDS.USER_3],
+                        memberCount: 1,
+                    }),
+                ]),
+            })
+        })
+
+        it('should handle empty groupIds array by fetching all groups', async () => {
+            mockTwistApi.groups.getGroups.mockResolvedValue([createMockGroup()])
+
+            const result = await getGroups.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1, groupIds: [] },
+                mockTwistApi,
+            )
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.groups).toHaveLength(1)
+        })
+    })
+
+    describe('filtering groups', () => {
+        it('should filter groups by ID', async () => {
+            const mockGroups = [
+                createMockGroup({ id: 100, name: 'Product Automation' }),
+                createMockGroup({ id: 200, name: 'Engineering' }),
+                createMockGroup({ id: 300, name: 'Marketing' }),
+            ]
+
+            mockTwistApi.groups.getGroups.mockResolvedValue(mockGroups)
+
+            const result = await getGroups.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1, groupIds: [100, 300] },
+                mockTwistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('**Total Groups:** 2')
+            expect(textContent).toContain('## Product Automation')
+            expect(textContent).toContain('## Marketing')
+            expect(textContent).not.toContain('## Engineering')
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.totalGroups).toBe(2)
+            expect(structuredContent.groups).toHaveLength(2)
+        })
+
+        it('should filter groups by name search case-insensitively', async () => {
+            const mockGroups = [
+                createMockGroup({ id: 100, name: 'Product Automation' }),
+                createMockGroup({ id: 200, name: 'Engineering' }),
+                createMockGroup({ id: 300, name: 'Automation QA' }),
+            ]
+
+            mockTwistApi.groups.getGroups.mockResolvedValue(mockGroups)
+
+            const result = await getGroups.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1, searchText: 'AUTOMATION' },
+                mockTwistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('**Total Groups:** 3 (2 matching search)')
+            expect(textContent).toContain('## Product Automation')
+            expect(textContent).toContain('## Automation QA')
+            expect(textContent).not.toContain('## Engineering')
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.totalGroups).toBe(3)
+            expect(structuredContent.filteredGroups).toBe(2)
+            expect(structuredContent.groups).toHaveLength(2)
+        })
+
+        it('should combine ID and search filters', async () => {
+            const mockGroups = [
+                createMockGroup({ id: 100, name: 'Product Automation' }),
+                createMockGroup({ id: 200, name: 'Engineering Automation' }),
+                createMockGroup({ id: 300, name: 'Marketing' }),
+            ]
+
+            mockTwistApi.groups.getGroups.mockResolvedValue(mockGroups)
+
+            const result = await getGroups.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1, groupIds: [100, 300], searchText: 'auto' },
+                mockTwistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('**Total Groups:** 2 (1 matching search)')
+            expect(textContent).toContain('## Product Automation')
+            expect(textContent).not.toContain('## Engineering Automation')
+            expect(textContent).not.toContain('## Marketing')
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.totalGroups).toBe(2)
+            expect(structuredContent.filteredGroups).toBe(1)
+            expect(structuredContent.groups).toHaveLength(1)
+        })
+
+        it('should handle no matching groups', async () => {
+            mockTwistApi.groups.getGroups.mockResolvedValue([createMockGroup()])
+
+            const result = await getGroups.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1, searchText: 'nonexistent' },
+                mockTwistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('**Total Groups:** 1 (0 matching search)')
+            expect(textContent).toContain('No groups found.')
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.totalGroups).toBe(1)
+            expect(structuredContent.filteredGroups).toBe(0)
+            expect(structuredContent.groups).toHaveLength(0)
+        })
+    })
+
+    describe('edge cases', () => {
+        it('should handle empty group list', async () => {
+            mockTwistApi.groups.getGroups.mockResolvedValue([])
+
+            const result = await getGroups.execute(
+                { workspaceId: TEST_IDS.WORKSPACE_1 },
+                mockTwistApi,
+            )
+
+            const textContent = extractTextContent(result)
+            expect(textContent).toContain('**Total Groups:** 0')
+            expect(textContent).toContain('No groups found.')
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.groups).toHaveLength(0)
+        })
+    })
+
+    describe('error handling', () => {
+        it('should propagate API errors', async () => {
+            const apiError = new Error(TEST_ERRORS.API_UNAUTHORIZED)
+            mockTwistApi.groups.getGroups.mockRejectedValue(apiError)
+
+            await expect(
+                getGroups.execute({ workspaceId: TEST_IDS.WORKSPACE_1 }, mockTwistApi),
+            ).rejects.toThrow(TEST_ERRORS.API_UNAUTHORIZED)
+        })
+    })
+})

--- a/src/tools/__tests__/get-groups.test.ts
+++ b/src/tools/__tests__/get-groups.test.ts
@@ -12,7 +12,9 @@ import { getGroups } from '../get-groups.js'
 const mockTwistApi = {
     groups: {
         getGroups: jest.fn(),
+        getGroup: jest.fn(),
     },
+    batch: jest.fn(),
 } as unknown as jest.Mocked<TwistApi>
 
 const { GET_GROUPS } = ToolNames
@@ -30,6 +32,14 @@ const createMockGroup = (overrides: Partial<Group> = {}): Group => ({
 describe(`${GET_GROUPS} tool`, () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        mockTwistApi.batch.mockImplementation(async (...args: readonly unknown[]) => {
+            const results = []
+            for (const arg of args) {
+                const result = await arg
+                results.push({ data: result })
+            }
+            return results as never
+        })
     })
 
     describe('fetching groups', () => {
@@ -52,6 +62,7 @@ describe(`${GET_GROUPS} tool`, () => {
             )
 
             expect(mockTwistApi.groups.getGroups).toHaveBeenCalledWith(TEST_IDS.WORKSPACE_1)
+            expect(mockTwistApi.batch).not.toHaveBeenCalled()
 
             const textContent = extractTextContent(result)
             expect(textContent).toContain(`**Workspace ID:** ${TEST_IDS.WORKSPACE_1}`)
@@ -82,6 +93,7 @@ describe(`${GET_GROUPS} tool`, () => {
             })
             expect(structuredContent.groups[0]).not.toHaveProperty('description')
             expect(structuredContent.groups[0]).not.toHaveProperty('userIds')
+            expect(structuredContent.groups[0]).not.toHaveProperty('version')
         })
 
         it('should handle empty groupIds array by fetching all groups', async () => {
@@ -99,18 +111,29 @@ describe(`${GET_GROUPS} tool`, () => {
 
     describe('filtering groups', () => {
         it('should filter groups by ID', async () => {
-            const mockGroups = [
-                createMockGroup({ id: 100, name: 'Product Automation' }),
-                createMockGroup({ id: 200, name: 'Engineering' }),
-                createMockGroup({ id: 300, name: 'Marketing' }),
-            ]
-
-            mockTwistApi.groups.getGroups.mockResolvedValue(mockGroups)
+            mockTwistApi.groups.getGroup.mockImplementation(async (id: number) => {
+                if (id === 100) {
+                    return createMockGroup({ id: 100, name: 'Product Automation' })
+                }
+                if (id === 300) {
+                    return createMockGroup({ id: 300, name: 'Marketing' })
+                }
+                throw new Error('Group not found')
+            })
 
             const result = await getGroups.execute(
                 { workspaceId: TEST_IDS.WORKSPACE_1, groupIds: [100, 300] },
                 mockTwistApi,
             )
+
+            expect(mockTwistApi.groups.getGroups).not.toHaveBeenCalled()
+            expect(mockTwistApi.groups.getGroup).toHaveBeenNthCalledWith(1, 100, {
+                batch: true,
+            })
+            expect(mockTwistApi.groups.getGroup).toHaveBeenNthCalledWith(2, 300, {
+                batch: true,
+            })
+            expect(mockTwistApi.batch).toHaveBeenCalledTimes(1)
 
             const textContent = extractTextContent(result)
             expect(textContent).toContain('**Total Groups:** 2')
@@ -150,18 +173,23 @@ describe(`${GET_GROUPS} tool`, () => {
         })
 
         it('should combine ID and search filters', async () => {
-            const mockGroups = [
-                createMockGroup({ id: 100, name: 'Product Automation' }),
-                createMockGroup({ id: 200, name: 'Engineering Automation' }),
-                createMockGroup({ id: 300, name: 'Marketing' }),
-            ]
-
-            mockTwistApi.groups.getGroups.mockResolvedValue(mockGroups)
+            mockTwistApi.groups.getGroup.mockImplementation(async (id: number) => {
+                if (id === 100) {
+                    return createMockGroup({ id: 100, name: 'Product Automation' })
+                }
+                if (id === 300) {
+                    return createMockGroup({ id: 300, name: 'Marketing' })
+                }
+                throw new Error('Group not found')
+            })
 
             const result = await getGroups.execute(
                 { workspaceId: TEST_IDS.WORKSPACE_1, groupIds: [100, 300], searchText: 'auto' },
                 mockTwistApi,
             )
+
+            expect(mockTwistApi.groups.getGroups).not.toHaveBeenCalled()
+            expect(mockTwistApi.batch).toHaveBeenCalledTimes(1)
 
             const textContent = extractTextContent(result)
             expect(textContent).toContain('**Total Groups:** 2 (1 matching search)')

--- a/src/tools/__tests__/reply.test.ts
+++ b/src/tools/__tests__/reply.test.ts
@@ -44,7 +44,7 @@ describe(`${REPLY} tool`, () => {
             expect(mockTwistApi.comments.createComment).toHaveBeenCalledWith({
                 threadId: TEST_IDS.THREAD_1,
                 content: 'This is my reply',
-                recipients: undefined,
+                recipients: 'EVERYONE_IN_THREAD',
                 groups: undefined,
             })
 
@@ -64,6 +64,7 @@ describe(`${REPLY} tool`, () => {
             )
             expect(structuredContent?.replyId).toBe(mockComment.id)
             expect(structuredContent?.created).toBe('2024-01-01T00:00:00.000Z')
+            expect(structuredContent?.recipientMode).toBe('EVERYONE_IN_THREAD')
         })
 
         it('should post a comment with recipients', async () => {
@@ -92,6 +93,7 @@ describe(`${REPLY} tool`, () => {
             const structuredContent = extractStructuredContent(result)
             expect(structuredContent.recipients).toEqual([TEST_IDS.USER_1, TEST_IDS.USER_2])
             expect(structuredContent).not.toHaveProperty('groups')
+            expect(structuredContent).not.toHaveProperty('recipientMode')
         })
 
         it('should post a comment with groups', async () => {
@@ -118,6 +120,33 @@ describe(`${REPLY} tool`, () => {
             const structuredContent = extractStructuredContent(result)
             expect(structuredContent.groups).toEqual([100, 200])
             expect(structuredContent).not.toHaveProperty('recipients')
+            expect(structuredContent).not.toHaveProperty('recipientMode')
+        })
+
+        it('should use the default thread reply recipient mode when groups are empty', async () => {
+            const mockComment = createMockComment()
+            mockTwistApi.comments.createComment.mockResolvedValue(mockComment)
+
+            const result = await reply.execute(
+                {
+                    targetType: 'thread',
+                    targetId: TEST_IDS.THREAD_1,
+                    content: 'Notifying default recipients',
+                    groups: [],
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.comments.createComment).toHaveBeenCalledWith({
+                threadId: TEST_IDS.THREAD_1,
+                content: 'Notifying default recipients',
+                recipients: 'EVERYONE_IN_THREAD',
+                groups: undefined,
+            })
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.recipientMode).toBe('EVERYONE_IN_THREAD')
+            expect(structuredContent).not.toHaveProperty('groups')
         })
 
         it('should post a comment with recipients and groups', async () => {
@@ -145,6 +174,7 @@ describe(`${REPLY} tool`, () => {
             const structuredContent = extractStructuredContent(result)
             expect(structuredContent.recipients).toEqual([TEST_IDS.USER_1])
             expect(structuredContent.groups).toEqual([100])
+            expect(structuredContent).not.toHaveProperty('recipientMode')
         })
     })
 

--- a/src/tools/__tests__/reply.test.ts
+++ b/src/tools/__tests__/reply.test.ts
@@ -200,7 +200,39 @@ describe(`${REPLY} tool`, () => {
             expect(extractTextContent(result)).toMatchSnapshot()
         })
 
-        it('should not pass groups to conversation messages', async () => {
+        it('should reject groups for conversation messages', async () => {
+            await expect(
+                reply.execute(
+                    {
+                        targetType: 'conversation',
+                        targetId: TEST_IDS.CONVERSATION_1,
+                        content: 'This is my message',
+                        groups: [100],
+                    },
+                    mockTwistApi,
+                ),
+            ).rejects.toThrow('groups can only be used when replying to a thread.')
+
+            expect(mockTwistApi.conversationMessages.createMessage).not.toHaveBeenCalled()
+        })
+
+        it('should reject empty groups for conversation messages', async () => {
+            await expect(
+                reply.execute(
+                    {
+                        targetType: 'conversation',
+                        targetId: TEST_IDS.CONVERSATION_1,
+                        content: 'This is my message',
+                        groups: [],
+                    },
+                    mockTwistApi,
+                ),
+            ).rejects.toThrow('groups can only be used when replying to a thread.')
+
+            expect(mockTwistApi.conversationMessages.createMessage).not.toHaveBeenCalled()
+        })
+
+        it('should ignore recipients for conversation messages', async () => {
             const mockMessage = createMockConversationMessage()
             mockTwistApi.conversationMessages.createMessage.mockResolvedValue(mockMessage)
 
@@ -209,7 +241,7 @@ describe(`${REPLY} tool`, () => {
                     targetType: 'conversation',
                     targetId: TEST_IDS.CONVERSATION_1,
                     content: 'This is my message',
-                    groups: [100],
+                    recipients: [TEST_IDS.USER_1],
                 },
                 mockTwistApi,
             )

--- a/src/tools/__tests__/reply.test.ts
+++ b/src/tools/__tests__/reply.test.ts
@@ -3,6 +3,7 @@ import { jest } from '@jest/globals'
 import {
     createMockComment,
     createMockConversationMessage,
+    extractStructuredContent,
     extractTextContent,
     TEST_IDS,
 } from '../../utils/test-helpers.js'
@@ -44,6 +45,7 @@ describe(`${REPLY} tool`, () => {
                 threadId: TEST_IDS.THREAD_1,
                 content: 'This is my reply',
                 recipients: undefined,
+                groups: undefined,
             })
 
             expect(extractTextContent(result)).toMatchSnapshot()
@@ -82,9 +84,67 @@ describe(`${REPLY} tool`, () => {
                 threadId: TEST_IDS.THREAD_1,
                 content: 'Notifying users',
                 recipients: [TEST_IDS.USER_1, TEST_IDS.USER_2],
+                groups: undefined,
             })
 
             expect(extractTextContent(result)).toMatchSnapshot()
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.recipients).toEqual([TEST_IDS.USER_1, TEST_IDS.USER_2])
+            expect(structuredContent).not.toHaveProperty('groups')
+        })
+
+        it('should post a comment with groups', async () => {
+            const mockComment = createMockComment()
+            mockTwistApi.comments.createComment.mockResolvedValue(mockComment)
+
+            const result = await reply.execute(
+                {
+                    targetType: 'thread',
+                    targetId: TEST_IDS.THREAD_1,
+                    content: 'Notifying groups',
+                    groups: [100, 200],
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.comments.createComment).toHaveBeenCalledWith({
+                threadId: TEST_IDS.THREAD_1,
+                content: 'Notifying groups',
+                recipients: undefined,
+                groups: [100, 200],
+            })
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.groups).toEqual([100, 200])
+            expect(structuredContent).not.toHaveProperty('recipients')
+        })
+
+        it('should post a comment with recipients and groups', async () => {
+            const mockComment = createMockComment()
+            mockTwistApi.comments.createComment.mockResolvedValue(mockComment)
+
+            const result = await reply.execute(
+                {
+                    targetType: 'thread',
+                    targetId: TEST_IDS.THREAD_1,
+                    content: 'Notifying users and groups',
+                    recipients: [TEST_IDS.USER_1],
+                    groups: [100],
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.comments.createComment).toHaveBeenCalledWith({
+                threadId: TEST_IDS.THREAD_1,
+                content: 'Notifying users and groups',
+                recipients: [TEST_IDS.USER_1],
+                groups: [100],
+            })
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent.recipients).toEqual([TEST_IDS.USER_1])
+            expect(structuredContent.groups).toEqual([100])
         })
     })
 
@@ -108,6 +168,29 @@ describe(`${REPLY} tool`, () => {
             })
 
             expect(extractTextContent(result)).toMatchSnapshot()
+        })
+
+        it('should not pass groups to conversation messages', async () => {
+            const mockMessage = createMockConversationMessage()
+            mockTwistApi.conversationMessages.createMessage.mockResolvedValue(mockMessage)
+
+            const result = await reply.execute(
+                {
+                    targetType: 'conversation',
+                    targetId: TEST_IDS.CONVERSATION_1,
+                    content: 'This is my message',
+                    groups: [100],
+                },
+                mockTwistApi,
+            )
+
+            expect(mockTwistApi.conversationMessages.createMessage).toHaveBeenCalledWith({
+                conversationId: TEST_IDS.CONVERSATION_1,
+                content: 'This is my message',
+            })
+
+            const structuredContent = extractStructuredContent(result)
+            expect(structuredContent).not.toHaveProperty('groups')
         })
     })
 

--- a/src/tools/__tests__/tool-annotations.test.ts
+++ b/src/tools/__tests__/tool-annotations.test.ts
@@ -69,6 +69,13 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         idempotentHint: true,
     },
     {
+        name: ToolNames.GET_GROUPS,
+        title: 'Twist: Get Groups',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    {
         name: ToolNames.GET_WORKSPACES,
         title: 'Twist: Get Workspaces',
         readOnlyHint: true,

--- a/src/tools/create-thread.ts
+++ b/src/tools/create-thread.ts
@@ -26,7 +26,7 @@ const ArgsSchema = {
 const createThread = {
     name: ToolNames.CREATE_THREAD,
     description:
-        'Create a new thread in a workspace channel. Requires a channel ID, title, and content. Optionally notify specific users.',
+        'Create a new thread in a workspace channel. Requires a channel ID, title, and content. Optionally notify specific users or groups.',
     parameters: ArgsSchema,
     outputSchema: CreateThreadOutputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },

--- a/src/tools/create-thread.ts
+++ b/src/tools/create-thread.ts
@@ -83,8 +83,8 @@ const createThread = {
             creator: thread.creator,
             created: created.toISOString(),
             threadUrl,
-            ...(recipients && { recipients }),
-            ...(groups && { groups }),
+            ...(recipients ? { recipients } : {}),
+            ...(groups ? { groups } : {}),
         }
 
         return getToolOutput({

--- a/src/tools/create-thread.ts
+++ b/src/tools/create-thread.ts
@@ -15,6 +15,12 @@ const ArgsSchema = {
         .describe(
             'Optional array of user IDs to notify. If omitted, Twist defaults to notifying all current members of the channel (equivalent to the API\'s "EVERYONE" default). Note: workspace users who have not joined this channel will not be notified — add their IDs explicitly if you want to reach them.',
         ),
+    groups: z
+        .array(z.number())
+        .optional()
+        .describe(
+            'Optional array of group IDs to notify. Use get-groups to discover group IDs before passing them here.',
+        ),
 }
 
 const createThread = {
@@ -25,13 +31,14 @@ const createThread = {
     outputSchema: CreateThreadOutputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     async execute(args, client) {
-        const { channelId, title, content, recipients } = args
+        const { channelId, title, content, recipients, groups } = args
 
         const thread = await client.threads.createThread({
             channelId,
             title,
             content,
             recipients,
+            groups,
         })
 
         const postedValue = thread.posted
@@ -76,6 +83,8 @@ const createThread = {
             creator: thread.creator,
             created: created.toISOString(),
             threadUrl,
+            ...(recipients && { recipients }),
+            ...(groups && { groups }),
         }
 
         return getToolOutput({

--- a/src/tools/get-groups.ts
+++ b/src/tools/get-groups.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TwistTool } from '../twist-tool.js'
-import { GetGroupsOutputSchema } from '../utils/output-schemas.js'
+import { type GetGroupsOutput, GetGroupsOutputSchema } from '../utils/output-schemas.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 const ArgsSchema = {
@@ -18,23 +18,7 @@ const ArgsSchema = {
         .describe('Optional search text to filter groups by name (case-insensitive).'),
 }
 
-type GroupData = {
-    id: number
-    name: string
-    description?: string
-    workspaceId: number
-    userIds: number[]
-    memberCount: number
-    version: number
-}
-
-type GetGroupsStructured = Record<string, unknown> & {
-    type: 'get_groups'
-    workspaceId: number
-    groups: GroupData[]
-    totalGroups: number
-    filteredGroups: number
-}
+type GetGroupsStructured = GetGroupsOutput
 
 const getGroups = {
     name: ToolNames.GET_GROUPS,
@@ -77,9 +61,6 @@ const getGroups = {
                 lines.push(`## ${group.name}`)
                 lines.push(`**ID:** ${group.id}`)
                 lines.push(`**Members:** ${group.userIds.length}`)
-                if (group.description) {
-                    lines.push(`**Description:** ${group.description}`)
-                }
                 lines.push('')
             }
         }
@@ -92,9 +73,7 @@ const getGroups = {
             groups: filteredGroups.map((group) => ({
                 id: group.id,
                 name: group.name,
-                ...(group.description && { description: group.description }),
                 workspaceId: group.workspaceId,
-                userIds: group.userIds,
                 memberCount: group.userIds.length,
                 version: group.version,
             })),

--- a/src/tools/get-groups.ts
+++ b/src/tools/get-groups.ts
@@ -30,12 +30,19 @@ const getGroups = {
     async execute(args, client) {
         const { workspaceId, groupIds, searchText } = args
 
-        const workspaceGroups = await client.groups.getGroups(workspaceId)
-        const requestedGroupIds = groupIds && groupIds.length > 0 ? new Set(groupIds) : undefined
-
+        const requestedGroupIds =
+            groupIds && groupIds.length > 0 ? [...new Set(groupIds)] : undefined
         const groups = requestedGroupIds
-            ? workspaceGroups.filter((group) => requestedGroupIds.has(group.id))
-            : workspaceGroups
+            ? await (async () => {
+                  const groupRequests = requestedGroupIds.map((groupId) =>
+                      client.groups.getGroup(groupId, { batch: true }),
+                  )
+                  const groupResponses = await client.batch(...groupRequests)
+                  return groupResponses
+                      .map((response) => response.data)
+                      .filter((group) => group.workspaceId === workspaceId)
+              })()
+            : await client.groups.getGroups(workspaceId)
         const totalGroups = groups.length
 
         let filteredGroups = groups
@@ -75,7 +82,6 @@ const getGroups = {
                 name: group.name,
                 workspaceId: group.workspaceId,
                 memberCount: group.userIds.length,
-                version: group.version,
             })),
             totalGroups,
             filteredGroups: filteredGroups.length,

--- a/src/tools/get-groups.ts
+++ b/src/tools/get-groups.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod'
+import { getToolOutput } from '../mcp-helpers.js'
+import type { TwistTool } from '../twist-tool.js'
+import { GetGroupsOutputSchema } from '../utils/output-schemas.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    workspaceId: z.number().describe('The workspace ID to get groups from.'),
+    groupIds: z
+        .array(z.number())
+        .optional()
+        .describe(
+            'Optional array of specific group IDs to fetch. If not provided or empty array, fetches all workspace groups.',
+        ),
+    searchText: z
+        .string()
+        .optional()
+        .describe('Optional search text to filter groups by name (case-insensitive).'),
+}
+
+type GroupData = {
+    id: number
+    name: string
+    description?: string
+    workspaceId: number
+    userIds: number[]
+    memberCount: number
+    version: number
+}
+
+type GetGroupsStructured = Record<string, unknown> & {
+    type: 'get_groups'
+    workspaceId: number
+    groups: GroupData[]
+    totalGroups: number
+    filteredGroups: number
+}
+
+const getGroups = {
+    name: ToolNames.GET_GROUPS,
+    description:
+        'Get groups from a workspace. Retrieves all workspace groups by default, or specific groups if groupIds array is provided. Supports optional case-insensitive search filtering by group name. Use this before passing group IDs to tools that support group notifications.',
+    parameters: ArgsSchema,
+    outputSchema: GetGroupsOutputSchema.shape,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    async execute(args, client) {
+        const { workspaceId, groupIds, searchText } = args
+
+        const workspaceGroups = await client.groups.getGroups(workspaceId)
+        const requestedGroupIds = groupIds && groupIds.length > 0 ? new Set(groupIds) : undefined
+
+        const groups = requestedGroupIds
+            ? workspaceGroups.filter((group) => requestedGroupIds.has(group.id))
+            : workspaceGroups
+        const totalGroups = groups.length
+
+        let filteredGroups = groups
+        if (searchText) {
+            const searchLower = searchText.toLowerCase()
+            filteredGroups = groups.filter((group) =>
+                group.name.toLowerCase().includes(searchLower),
+            )
+        }
+
+        const lines: string[] = ['# Workspace Groups', '']
+
+        lines.push(`**Workspace ID:** ${workspaceId}`)
+        lines.push(
+            `**Total Groups:** ${totalGroups}${searchText ? ` (${filteredGroups.length} matching search)` : ''}`,
+        )
+        lines.push('')
+
+        if (filteredGroups.length === 0) {
+            lines.push('No groups found.')
+        } else {
+            for (const group of filteredGroups) {
+                lines.push(`## ${group.name}`)
+                lines.push(`**ID:** ${group.id}`)
+                lines.push(`**Members:** ${group.userIds.length}`)
+                if (group.description) {
+                    lines.push(`**Description:** ${group.description}`)
+                }
+                lines.push('')
+            }
+        }
+
+        const textContent = lines.join('\n')
+
+        const structuredContent: GetGroupsStructured = {
+            type: 'get_groups',
+            workspaceId,
+            groups: filteredGroups.map((group) => ({
+                id: group.id,
+                name: group.name,
+                ...(group.description && { description: group.description }),
+                workspaceId: group.workspaceId,
+                userIds: group.userIds,
+                memberCount: group.userIds.length,
+                version: group.version,
+            })),
+            totalGroups,
+            filteredGroups: filteredGroups.length,
+        }
+
+        return getToolOutput({
+            textContent,
+            structuredContent,
+        })
+    },
+} satisfies TwistTool<typeof ArgsSchema, typeof GetGroupsOutputSchema.shape>
+
+export { getGroups, type GetGroupsStructured }

--- a/src/tools/reply.ts
+++ b/src/tools/reply.ts
@@ -11,6 +11,7 @@ import { type ReplyOutput, ReplyOutputSchema } from '../utils/output-schemas.js'
 import { ReplyTargetTypeSchema } from '../utils/target-types.js'
 import { ToolNames } from '../utils/tool-names.js'
 
+// TODO: import this from twist-sdk once Doist/twist-sdk-typescript#125 ships.
 const DEFAULT_THREAD_REPLY_RECIPIENTS = 'EVERYONE_IN_THREAD' as const
 
 const ArgsSchema = {
@@ -47,7 +48,7 @@ async function createThreadReplyComment(
     client: TwistApi,
     args: CreateThreadReplyCommentArgs,
 ): Promise<Comment> {
-    // The Twist API accepts comment groups, but twist-sdk has not typed that field yet.
+    // The Twist API accepts comment groups; replace this wrapper after Doist/twist-sdk-typescript#124.
     const comments = client.comments as unknown as CommentsClientWithGroupRecipients
     return comments.createComment(args)
 }
@@ -138,11 +139,11 @@ const reply = {
             content,
             created: created.toISOString(),
             replyUrl,
-            ...(targetType === 'thread' && recipients && { recipients }),
-            ...(targetType === 'thread' &&
-                !recipients &&
-                !groupsToNotify && { recipientMode: DEFAULT_THREAD_REPLY_RECIPIENTS }),
-            ...(targetType === 'thread' && groupsToNotify && { groups: groupsToNotify }),
+            ...(targetType === 'thread' && recipients ? { recipients } : {}),
+            ...(targetType === 'thread' && !recipients && !groupsToNotify
+                ? { recipientMode: DEFAULT_THREAD_REPLY_RECIPIENTS }
+                : {}),
+            ...(targetType === 'thread' && groupsToNotify ? { groups: groupsToNotify } : {}),
         }
 
         return getToolOutput({

--- a/src/tools/reply.ts
+++ b/src/tools/reply.ts
@@ -1,9 +1,14 @@
-import { getFullTwistURL } from '@doist/twist-sdk'
+import {
+    getFullTwistURL,
+    type Comment,
+    type CreateCommentArgs,
+    type TwistApi,
+} from '@doist/twist-sdk'
 import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TwistTool } from '../twist-tool.js'
-import { ReplyOutputSchema } from '../utils/output-schemas.js'
-import { type ReplyTargetType, ReplyTargetTypeSchema } from '../utils/target-types.js'
+import { type ReplyOutput, ReplyOutputSchema } from '../utils/output-schemas.js'
+import { ReplyTargetTypeSchema } from '../utils/target-types.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 const DEFAULT_THREAD_REPLY_RECIPIENTS = 'EVERYONE_IN_THREAD' as const
@@ -28,18 +33,23 @@ const ArgsSchema = {
         ),
 }
 
-type ReplyStructured = {
-    type: 'reply_result'
-    success: boolean
-    targetType: ReplyTargetType
-    targetId: number
-    replyId: number
-    content: string
-    created: string
-    replyUrl: string
-    recipients?: number[]
-    recipientMode?: typeof DEFAULT_THREAD_REPLY_RECIPIENTS
+type ReplyStructured = ReplyOutput
+type ThreadReplyRecipients = number[] | typeof DEFAULT_THREAD_REPLY_RECIPIENTS
+type CreateThreadReplyCommentArgs = Omit<CreateCommentArgs, 'recipients'> & {
+    recipients?: ThreadReplyRecipients
     groups?: number[]
+}
+type CommentsClientWithGroupRecipients = {
+    createComment(args: CreateThreadReplyCommentArgs): Promise<Comment>
+}
+
+async function createThreadReplyComment(
+    client: TwistApi,
+    args: CreateThreadReplyCommentArgs,
+): Promise<Comment> {
+    // The Twist API accepts comment groups, but twist-sdk has not typed that field yet.
+    const comments = client.comments as unknown as CommentsClientWithGroupRecipients
+    return comments.createComment(args)
 }
 
 const reply = {
@@ -58,19 +68,19 @@ const reply = {
         const groupsToNotify =
             targetType === 'thread' && groups && groups.length > 0 ? groups : undefined
 
+        if (targetType === 'conversation' && groups !== undefined) {
+            throw new Error('groups can only be used when replying to a thread.')
+        }
+
         if (targetType === 'thread') {
             const resolvedRecipients =
                 recipients ?? (groupsToNotify ? undefined : DEFAULT_THREAD_REPLY_RECIPIENTS)
-            const commentArgs = {
+            const comment = await createThreadReplyComment(client, {
                 threadId: targetId,
                 content,
                 recipients: resolvedRecipients,
                 groups: groupsToNotify,
-            } as Parameters<typeof client.comments.createComment>[0] & {
-                recipients?: number[] | typeof DEFAULT_THREAD_REPLY_RECIPIENTS
-                groups?: number[]
-            }
-            const comment = await client.comments.createComment(commentArgs)
+            })
             replyId = comment.id
             replyUrl =
                 comment.url ??

--- a/src/tools/reply.ts
+++ b/src/tools/reply.ts
@@ -6,6 +6,8 @@ import { ReplyOutputSchema } from '../utils/output-schemas.js'
 import { type ReplyTargetType, ReplyTargetTypeSchema } from '../utils/target-types.js'
 import { ToolNames } from '../utils/tool-names.js'
 
+const DEFAULT_THREAD_REPLY_RECIPIENTS = 'EVERYONE_IN_THREAD' as const
+
 const ArgsSchema = {
     targetType: ReplyTargetTypeSchema.describe(
         'The type of object to reply to: thread (posts a comment) or conversation (posts a message).',
@@ -16,7 +18,7 @@ const ArgsSchema = {
         .array(z.number())
         .optional()
         .describe(
-            'Optional array of user IDs to notify (only for thread replies). If omitted, Twist defaults to notifying all current members of the channel. Add specific user IDs to limit or expand notifications beyond current channel members.',
+            'Optional array of user IDs to notify (only for thread replies). If omitted with no groups, thread replies notify everyone who has interacted with the thread.',
         ),
     groups: z
         .array(z.number())
@@ -36,13 +38,14 @@ type ReplyStructured = {
     created: string
     replyUrl: string
     recipients?: number[]
+    recipientMode?: typeof DEFAULT_THREAD_REPLY_RECIPIENTS
     groups?: number[]
 }
 
 const reply = {
     name: ToolNames.REPLY,
     description:
-        'Post a reply to a thread (as a comment) or conversation (as a message). Use targetType to specify thread or conversation, and targetId for the ID.',
+        'Post a reply to a thread (as a comment) or conversation (as a message). Thread replies notify everyone who has interacted with the thread by default unless specific user recipients or groups are provided.',
     parameters: ArgsSchema,
     outputSchema: ReplyOutputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
@@ -52,14 +55,21 @@ const reply = {
         let replyId: number
         let created: Date
         let replyUrl: string
+        const groupsToNotify =
+            targetType === 'thread' && groups && groups.length > 0 ? groups : undefined
 
         if (targetType === 'thread') {
+            const resolvedRecipients =
+                recipients ?? (groupsToNotify ? undefined : DEFAULT_THREAD_REPLY_RECIPIENTS)
             const commentArgs = {
                 threadId: targetId,
                 content,
-                recipients,
-                groups,
-            } as Parameters<typeof client.comments.createComment>[0] & { groups?: number[] }
+                recipients: resolvedRecipients,
+                groups: groupsToNotify,
+            } as Parameters<typeof client.comments.createComment>[0] & {
+                recipients?: number[] | typeof DEFAULT_THREAD_REPLY_RECIPIENTS
+                groups?: number[]
+            }
             const comment = await client.comments.createComment(commentArgs)
             replyId = comment.id
             replyUrl =
@@ -119,7 +129,10 @@ const reply = {
             created: created.toISOString(),
             replyUrl,
             ...(targetType === 'thread' && recipients && { recipients }),
-            ...(targetType === 'thread' && groups && { groups }),
+            ...(targetType === 'thread' &&
+                !recipients &&
+                !groupsToNotify && { recipientMode: DEFAULT_THREAD_REPLY_RECIPIENTS }),
+            ...(targetType === 'thread' && groupsToNotify && { groups: groupsToNotify }),
         }
 
         return getToolOutput({

--- a/src/tools/reply.ts
+++ b/src/tools/reply.ts
@@ -18,6 +18,12 @@ const ArgsSchema = {
         .describe(
             'Optional array of user IDs to notify (only for thread replies). If omitted, Twist defaults to notifying all current members of the channel. Add specific user IDs to limit or expand notifications beyond current channel members.',
         ),
+    groups: z
+        .array(z.number())
+        .optional()
+        .describe(
+            'Optional array of group IDs to notify (only for thread replies). Use get-groups to discover group IDs before passing them here.',
+        ),
 }
 
 type ReplyStructured = {
@@ -29,6 +35,8 @@ type ReplyStructured = {
     content: string
     created: string
     replyUrl: string
+    recipients?: number[]
+    groups?: number[]
 }
 
 const reply = {
@@ -39,18 +47,20 @@ const reply = {
     outputSchema: ReplyOutputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
     async execute(args, client) {
-        const { targetType, targetId, content, recipients } = args
+        const { targetType, targetId, content, recipients, groups } = args
 
         let replyId: number
         let created: Date
         let replyUrl: string
 
         if (targetType === 'thread') {
-            const comment = await client.comments.createComment({
+            const commentArgs = {
                 threadId: targetId,
                 content,
                 recipients,
-            })
+                groups,
+            } as Parameters<typeof client.comments.createComment>[0] & { groups?: number[] }
+            const comment = await client.comments.createComment(commentArgs)
             replyId = comment.id
             replyUrl =
                 comment.url ??
@@ -108,6 +118,8 @@ const reply = {
             content,
             created: created.toISOString(),
             replyUrl,
+            ...(targetType === 'thread' && recipients && { recipients }),
+            ...(targetType === 'thread' && groups && { groups }),
         }
 
         return getToolOutput({

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -253,9 +253,7 @@ export const GetGroupsOutputSchema = z.object({
         z.object({
             id: z.number(),
             name: z.string(),
-            description: z.string().optional(),
             workspaceId: z.number(),
-            userIds: z.array(z.number()),
             memberCount: z.number(),
             version: z.number(),
         }),

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -255,7 +255,6 @@ export const GetGroupsOutputSchema = z.object({
             name: z.string(),
             workspaceId: z.number(),
             memberCount: z.number(),
-            version: z.number(),
         }),
     ),
     totalGroups: z.number(),

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -419,6 +419,7 @@ export const ReplyOutputSchema = z.object({
     created: z.string(),
     replyUrl: z.string(),
     recipients: z.array(z.number()).optional(),
+    recipientMode: z.literal('EVERYONE_IN_THREAD').optional(),
     groups: z.array(z.number()).optional(),
 })
 

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -243,6 +243,27 @@ export const GetUsersOutputSchema = z.object({
     filteredUsers: z.number(),
 })
 
+/**
+ * Schema for get-groups tool output
+ */
+export const GetGroupsOutputSchema = z.object({
+    type: z.literal('get_groups'),
+    workspaceId: z.number(),
+    groups: z.array(
+        z.object({
+            id: z.number(),
+            name: z.string(),
+            description: z.string().optional(),
+            workspaceId: z.number(),
+            userIds: z.array(z.number()),
+            memberCount: z.number(),
+            version: z.number(),
+        }),
+    ),
+    totalGroups: z.number(),
+    filteredGroups: z.number(),
+})
+
 export const AWAY_ACTIONS = ['get', 'set', 'clear'] as const
 export type AwayAction = (typeof AWAY_ACTIONS)[number]
 
@@ -306,6 +327,8 @@ export const CreateThreadOutputSchema = z.object({
     creator: z.number(),
     created: z.string(),
     threadUrl: z.string(),
+    recipients: z.array(z.number()).optional(),
+    groups: z.array(z.number()).optional(),
 })
 
 /**
@@ -395,6 +418,8 @@ export const ReplyOutputSchema = z.object({
     content: z.string(),
     created: z.string(),
     replyUrl: z.string(),
+    recipients: z.array(z.number()).optional(),
+    groups: z.array(z.number()).optional(),
 })
 
 /**
@@ -474,6 +499,7 @@ export const StructuredOutputSchema = z.union([
     SearchContentOutputSchema,
     GetWorkspacesOutputSchema,
     GetUsersOutputSchema,
+    GetGroupsOutputSchema,
     UserInfoOutputSchema,
     BuildLinkOutputSchema,
     CreateThreadOutputSchema,
@@ -507,6 +533,7 @@ export type FetchInboxOutput = z.infer<typeof FetchInboxOutputSchema>
 export type SearchContentOutput = z.infer<typeof SearchContentOutputSchema>
 export type GetWorkspacesOutput = z.infer<typeof GetWorkspacesOutputSchema>
 export type GetUsersOutput = z.infer<typeof GetUsersOutputSchema>
+export type GetGroupsOutput = z.infer<typeof GetGroupsOutputSchema>
 export type UserInfoOutput = z.infer<typeof UserInfoOutputSchema>
 export type BuildLinkOutput = z.infer<typeof BuildLinkOutputSchema>
 export type ReplyOutput = z.infer<typeof ReplyOutputSchema>

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -13,6 +13,7 @@ export const ToolNames = {
     BUILD_LINK: 'build-link',
     GET_WORKSPACES: 'get-workspaces',
     GET_USERS: 'get-users',
+    GET_GROUPS: 'get-groups',
     AWAY: 'away',
     LIST_CHANNELS: 'list-channels',
 } as const


### PR DESCRIPTION
## Summary

Agents can now resolve Twist group IDs and notify those groups from the thread-writing tools. This adds a read-only `get-groups` tool, then extends `create-thread` and thread replies to accept `groups` alongside user `recipients`.

Thread replies also now default to notifying everyone who has interacted with the thread instead of relying on Twist's broad channel default. The mutation tools echo requested `recipients` and `groups`, plus the thread-reply default recipient mode, in structured output so automations can confirm notification behavior.

## Details

- Adds `get-groups` with optional `groupIds` and `searchText` filters.
- Registers and exports the new tool through the MCP server, package index, direct runner, and tool annotation coverage.
- Passes `groups` through `create-thread`.
- Passes `groups` through `reply` for `targetType: "thread"` while leaving conversation replies unchanged.
- Sends `EVERYONE_IN_THREAD` for thread replies when no explicit users or groups are provided.
- Updates MCP instructions and output schemas so agents know to resolve group names with `get-groups` before writing.

Closes Doist/twist-ai#176.

## Test Plan

- `npm test`
- `npm run type-check`
- `npm run format:check`
- `npm run build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-111827?logo=openai&logoColor=white)
