### PR TITLE
feat: expose attachments in load-thread and load-conversation output

### DIFF
--- a/src/tools/__tests__/load-conversation.test.ts
+++ b/src/tools/__tests__/load-conversation.test.ts
@@ -231,6 +231,63 @@ describe(`${LOAD_CONVERSATION} tool`, () => {
         })
     })
 
+    describe('attachments', () => {
+        it('surfaces message attachments in structured + text output', async () => {
+            const mockConversation = createMockConversation({
+                userIds: [TEST_IDS.USER_1, TEST_IDS.USER_2],
+            })
+            const sampleAttachment = {
+                attachmentId: 'abc-123',
+                fileName: 'report.pdf',
+                fileSize: 4096,
+                title: 'report.pdf',
+                underlyingType: 'application/pdf',
+                uploadState: 'uploaded',
+                url: 'https://files.twist.com/abc/as/22222/report.pdf',
+                urlType: 'file',
+            }
+            const mockMessage = createMockConversationMessage({
+                id: TEST_IDS.MESSAGE_1,
+                attachments: [sampleAttachment],
+            })
+
+            mockTwistApi.conversations.getConversation.mockResolvedValue(mockConversation)
+            mockTwistApi.conversationMessages.getMessages.mockResolvedValue([mockMessage])
+            mockTwistApi.workspaceUsers.getUserById.mockResolvedValue({
+                id: TEST_IDS.USER_1,
+                name: 'Test User 1',
+                shortName: 'TU1',
+                email: 'user1@test.com',
+                userType: 'USER' as const,
+                bot: false,
+                removed: false,
+                timezone: 'UTC',
+                version: 1,
+            })
+
+            const result = await loadConversation.execute(
+                {
+                    conversationId: TEST_IDS.CONVERSATION_1,
+                    limit: 50,
+                    includeParticipants: true,
+                },
+                mockTwistApi,
+            )
+
+            const { structuredContent } = result
+            expect(structuredContent?.messages[0]?.attachments).toHaveLength(1)
+            expect(structuredContent?.messages[0]?.attachments?.[0]).toMatchObject({
+                fileName: 'report.pdf',
+                url: sampleAttachment.url,
+            })
+
+            const text = extractTextContent(result)
+            expect(text).toContain('**Attachments (1):**')
+            expect(text).toContain('report.pdf')
+            expect(text).toContain(sampleAttachment.url)
+        })
+    })
+
     describe('error handling', () => {
         it('should propagate conversation not found error', async () => {
             const apiError = new Error('Conversation not found')

--- a/src/tools/__tests__/load-thread.test.ts
+++ b/src/tools/__tests__/load-thread.test.ts
@@ -273,6 +273,116 @@ describe(`${LOAD_THREAD} tool`, () => {
         })
     })
 
+    describe('attachments', () => {
+        const baseChannel = {
+            id: 67890,
+            name: 'Test Channel',
+            workspaceId: TEST_IDS.WORKSPACE_1,
+            archived: false,
+            public: true,
+            color: 0,
+            creator: TEST_IDS.USER_1,
+            version: 1,
+        }
+        const baseUser = {
+            id: TEST_IDS.USER_1,
+            name: 'Test User 1',
+            shortName: 'TU1',
+            email: 'user1@test.com',
+            userType: 'USER' as const,
+            bot: false,
+            removed: false,
+            timezone: 'UTC',
+            version: 1,
+        }
+        const sampleAttachment = {
+            attachmentId: 'abc-123',
+            fileName: 'ssh-public-key.md',
+            fileSize: 580,
+            title: 'ssh-public-key.md',
+            underlyingType: 'application/octet-stream',
+            uploadState: 'uploaded',
+            url: 'https://files.twist.com/abc/as/22222/ssh-public-key.md',
+            urlType: 'file',
+        }
+
+        it('surfaces comment attachments in structured + text output', async () => {
+            const mockThread = createMockThread()
+            const mockComment = createMockComment({
+                id: TEST_IDS.COMMENT_1,
+                creator: TEST_IDS.USER_1,
+                attachments: [sampleAttachment],
+            })
+
+            mockTwistApi.threads.getThread.mockResolvedValue(mockThread)
+            mockTwistApi.comments.getComments.mockResolvedValue([mockComment])
+            mockTwistApi.channels.getChannel.mockResolvedValue({
+                ...baseChannel,
+                created: new Date(),
+            })
+            mockTwistApi.workspaceUsers.getUserById.mockResolvedValue(baseUser)
+
+            const result = await loadThread.execute(
+                { threadId: TEST_IDS.THREAD_1, limit: 50, includeParticipants: true },
+                mockTwistApi,
+            )
+
+            const { structuredContent } = result
+            expect(structuredContent?.comments[0]?.attachments).toHaveLength(1)
+            expect(structuredContent?.comments[0]?.attachments?.[0]).toMatchObject({
+                fileName: 'ssh-public-key.md',
+                url: sampleAttachment.url,
+            })
+
+            const text = extractTextContent(result)
+            expect(text).toContain('**Attachments (1):**')
+            expect(text).toContain('ssh-public-key.md')
+            expect(text).toContain(sampleAttachment.url)
+        })
+
+        it('surfaces thread-body attachments', async () => {
+            const mockThread = createMockThread({ attachments: [sampleAttachment] })
+            mockTwistApi.threads.getThread.mockResolvedValue(mockThread)
+            mockTwistApi.comments.getComments.mockResolvedValue([])
+            mockTwistApi.channels.getChannel.mockResolvedValue({
+                ...baseChannel,
+                created: new Date(),
+            })
+            mockTwistApi.workspaceUsers.getUserById.mockResolvedValue(baseUser)
+
+            const result = await loadThread.execute(
+                { threadId: TEST_IDS.THREAD_1, limit: 50, includeParticipants: true },
+                mockTwistApi,
+            )
+
+            const { structuredContent } = result
+            expect(structuredContent?.thread.attachments).toHaveLength(1)
+            expect(extractTextContent(result)).toContain('**Attachments (1):**')
+        })
+
+        it('omits attachments field when there are none', async () => {
+            const mockThread = createMockThread()
+            const mockComment = createMockComment({ attachments: [] })
+            mockTwistApi.threads.getThread.mockResolvedValue(mockThread)
+            mockTwistApi.comments.getComments.mockResolvedValue([mockComment])
+            mockTwistApi.channels.getChannel.mockResolvedValue({
+                ...baseChannel,
+                created: new Date(),
+            })
+            mockTwistApi.workspaceUsers.getUserById.mockResolvedValue(baseUser)
+
+            const result = await loadThread.execute(
+                { threadId: TEST_IDS.THREAD_1, limit: 50, includeParticipants: true },
+                mockTwistApi,
+            )
+
+            const { structuredContent } = result
+            expect(structuredContent?.thread.attachments).toBeUndefined()
+            expect(structuredContent?.comments[0]?.attachments).toBeUndefined()
+            expect(extractTextContent(result)).not.toContain('**Attachments')
+        })
+    })
+
     describe('error handling', () => {
         it('should propagate thread not found error', async () => {
             const apiError = new Error('Thread not found')

--- a/src/tools/load-conversation.ts
+++ b/src/tools/load-conversation.ts
@@ -2,6 +2,11 @@ import { getFullTwistURL, type WorkspaceUser } from '@doist/twist-sdk'
 import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TwistTool } from '../twist-tool.js'
+import {
+    type Attachment,
+    formatAttachmentsLine,
+    normalizeAttachments,
+} from '../utils/attachments.js'
 import { LoadConversationOutputSchema } from '../utils/output-schemas.js'
 import { ToolNames } from '../utils/tool-names.js'
 
@@ -30,8 +35,6 @@ const ArgsSchema = {
         .describe('Include participant user IDs in the response.'),
 }
 
-type Attachment = Record<string, unknown>
-
 type LoadConversationStructured = {
     type: 'conversation_data'
     conversation: {
@@ -54,32 +57,6 @@ type LoadConversationStructured = {
         attachments?: Attachment[]
     }>
     totalMessages: number
-}
-
-function normalizeAttachments(value: unknown): Attachment[] | undefined {
-    if (!Array.isArray(value) || value.length === 0) {
-        return undefined
-    }
-    return value.filter(
-        (item): item is Attachment =>
-            typeof item === 'object' && item !== null && !Array.isArray(item),
-    )
-}
-
-function formatAttachmentsLine(attachments: Attachment[] | undefined): string | undefined {
-    if (!attachments || attachments.length === 0) {
-        return undefined
-    }
-    const items = attachments
-        .map((a) => {
-            const name =
-                typeof a.fileName === 'string' ? a.fileName : (a.title as string | undefined)
-            const size = typeof a.fileSize === 'number' ? ` (${a.fileSize} bytes)` : ''
-            const url = typeof a.url === 'string' ? ` — ${a.url}` : ''
-            return name ? `${name}${size}${url}` : url ? url.slice(3) : '(unnamed attachment)'
-        })
-        .join('; ')
-    return `**Attachments (${attachments.length}):** ${items}`
 }
 
 const loadConversation = {

--- a/src/tools/load-conversation.ts
+++ b/src/tools/load-conversation.ts
@@ -30,6 +30,8 @@ const ArgsSchema = {
         .describe('Include participant user IDs in the response.'),
 }
 
+type Attachment = Record<string, unknown>
+
 type LoadConversationStructured = {
     type: 'conversation_data'
     conversation: {
@@ -49,8 +51,35 @@ type LoadConversationStructured = {
         conversationId: number
         posted: string
         messageUrl: string
+        attachments?: Attachment[]
     }>
     totalMessages: number
+}
+
+function normalizeAttachments(value: unknown): Attachment[] | undefined {
+    if (!Array.isArray(value) || value.length === 0) {
+        return undefined
+    }
+    return value.filter(
+        (item): item is Attachment =>
+            typeof item === 'object' && item !== null && !Array.isArray(item),
+    )
+}
+
+function formatAttachmentsLine(attachments: Attachment[] | undefined): string | undefined {
+    if (!attachments || attachments.length === 0) {
+        return undefined
+    }
+    const items = attachments
+        .map((a) => {
+            const name =
+                typeof a.fileName === 'string' ? a.fileName : (a.title as string | undefined)
+            const size = typeof a.fileSize === 'number' ? ` (${a.fileSize} bytes)` : ''
+            const url = typeof a.url === 'string' ? ` — ${a.url}` : ''
+            return name ? `${name}${size}${url}` : url ? url.slice(3) : '(unnamed attachment)'
+        })
+        .join('; ')
+    return `**Attachments (${attachments.length}):** ${items}`
 }
 
 const loadConversation = {
@@ -127,6 +156,11 @@ const loadConversation = {
             )
             lines.push('')
             lines.push(message.content)
+            const attachmentsLine = formatAttachmentsLine(normalizeAttachments(message.attachments))
+            if (attachmentsLine) {
+                lines.push('')
+                lines.push(attachmentsLine)
+            }
             lines.push('')
         }
 
@@ -160,6 +194,7 @@ const loadConversation = {
                         conversationId: m.conversationId,
                         messageId: m.id,
                     }),
+                attachments: normalizeAttachments(m.attachments),
             })),
             totalMessages: conversation.messageCount ?? 0,
         }

--- a/src/tools/load-thread.ts
+++ b/src/tools/load-thread.ts
@@ -30,6 +30,8 @@ const ArgsSchema = {
         .describe('Include participant user IDs in the response.'),
 }
 
+type Attachment = Record<string, unknown>
+
 type LoadThreadStructured = {
     type: 'thread_data'
     thread: {
@@ -48,6 +50,7 @@ type LoadThreadStructured = {
         participants?: number[]
         participantNames?: string[]
         threadUrl: string
+        attachments?: Attachment[]
     }
     comments: Array<{
         id: number
@@ -57,8 +60,35 @@ type LoadThreadStructured = {
         threadId: number
         posted: string
         commentUrl: string
+        attachments?: Attachment[]
     }>
     totalComments: number
+}
+
+function normalizeAttachments(value: unknown): Attachment[] | undefined {
+    if (!Array.isArray(value) || value.length === 0) {
+        return undefined
+    }
+    return value.filter(
+        (item): item is Attachment =>
+            typeof item === 'object' && item !== null && !Array.isArray(item),
+    )
+}
+
+function formatAttachmentsLine(attachments: Attachment[] | undefined): string | undefined {
+    if (!attachments || attachments.length === 0) {
+        return undefined
+    }
+    const items = attachments
+        .map((a) => {
+            const name =
+                typeof a.fileName === 'string' ? a.fileName : (a.title as string | undefined)
+            const size = typeof a.fileSize === 'number' ? ` (${a.fileSize} bytes)` : ''
+            const url = typeof a.url === 'string' ? ` — ${a.url}` : ''
+            return name ? `${name}${size}${url}` : url ? url.slice(3) : '(unnamed attachment)'
+        })
+        .join('; ')
+    return `**Attachments (${attachments.length}):** ${items}`
 }
 
 const loadThread = {
@@ -138,9 +168,18 @@ const loadThread = {
             '',
             thread.content,
             '',
-            `## Comments (${comments.length})`,
-            '',
         ]
+
+        const threadAttachmentsLine = formatAttachmentsLine(
+            normalizeAttachments(thread.attachments),
+        )
+        if (threadAttachmentsLine) {
+            lines.push(threadAttachmentsLine)
+            lines.push('')
+        }
+
+        lines.push(`## Comments (${comments.length})`)
+        lines.push('')
 
         for (const comment of comments) {
             const commentDate = comment.posted.toISOString()
@@ -151,6 +190,13 @@ const loadThread = {
             )
             lines.push('')
             lines.push(comment.content)
+            const commentAttachmentsLine = formatAttachmentsLine(
+                normalizeAttachments(comment.attachments),
+            )
+            if (commentAttachmentsLine) {
+                lines.push('')
+                lines.push(commentAttachmentsLine)
+            }
             lines.push('')
         }
 
@@ -192,6 +238,7 @@ const loadThread = {
                         channelId: thread.channelId,
                         threadId: thread.id,
                     }),
+                attachments: normalizeAttachments(thread.attachments),
             },
             comments: comments.map((c) => ({
                 id: c.id,
@@ -208,6 +255,7 @@ const loadThread = {
                         threadId: c.threadId,
                         commentId: c.id,
                     }),
+                attachments: normalizeAttachments(c.attachments),
             })),
             totalComments: thread.commentCount,
         }

--- a/src/tools/load-thread.ts
+++ b/src/tools/load-thread.ts
@@ -2,6 +2,11 @@ import { getFullTwistURL } from '@doist/twist-sdk'
 import { z } from 'zod'
 import { getToolOutput } from '../mcp-helpers.js'
 import type { TwistTool } from '../twist-tool.js'
+import {
+    type Attachment,
+    formatAttachmentsLine,
+    normalizeAttachments,
+} from '../utils/attachments.js'
 import { LoadThreadOutputSchema } from '../utils/output-schemas.js'
 import { ToolNames } from '../utils/tool-names.js'
 
@@ -29,8 +34,6 @@ const ArgsSchema = {
         .default(true)
         .describe('Include participant user IDs in the response.'),
 }
-
-type Attachment = Record<string, unknown>
 
 type LoadThreadStructured = {
     type: 'thread_data'
@@ -63,32 +66,6 @@ type LoadThreadStructured = {
         attachments?: Attachment[]
     }>
     totalComments: number
-}
-
-function normalizeAttachments(value: unknown): Attachment[] | undefined {
-    if (!Array.isArray(value) || value.length === 0) {
-        return undefined
-    }
-    return value.filter(
-        (item): item is Attachment =>
-            typeof item === 'object' && item !== null && !Array.isArray(item),
-    )
-}
-
-function formatAttachmentsLine(attachments: Attachment[] | undefined): string | undefined {
-    if (!attachments || attachments.length === 0) {
-        return undefined
-    }
-    const items = attachments
-        .map((a) => {
-            const name =
-                typeof a.fileName === 'string' ? a.fileName : (a.title as string | undefined)
-            const size = typeof a.fileSize === 'number' ? ` (${a.fileSize} bytes)` : ''
-            const url = typeof a.url === 'string' ? ` — ${a.url}` : ''
-            return name ? `${name}${size}${url}` : url ? url.slice(3) : '(unnamed attachment)'
-        })
-        .join('; ')
-    return `**Attachments (${attachments.length}):** ${items}`
 }
 
 const loadThread = {

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1,0 +1,51 @@
+import { type Attachment } from '@doist/twist-sdk'
+
+export type { Attachment }
+
+/**
+ * Separator between an attachment's label and its URL in the formatted text line.
+ * Kept in one place so the rendering logic below stays in sync with itself.
+ */
+const URL_SEPARATOR = ' — '
+
+/**
+ * Coerce a raw `attachments` value from the Twist API into a list of attachment
+ * objects, dropping anything that isn't a plain object. Returns `undefined` when
+ * there are no attachments so callers can omit the field entirely.
+ *
+ * Note: an attachment's `url` points at `files.twist.com/...` and currently
+ * requires a browser session cookie to download — there is no OAuth-authenticated
+ * attachment download endpoint on the public Twist REST API today.
+ */
+export function normalizeAttachments(value: unknown): Attachment[] | undefined {
+    if (!Array.isArray(value) || value.length === 0) {
+        return undefined
+    }
+    return value.filter(
+        (item): item is Attachment =>
+            typeof item === 'object' && item !== null && !Array.isArray(item),
+    )
+}
+
+/**
+ * Render a one-line `**Attachments (n):** ...` summary, or `undefined` when there
+ * are none. Each attachment shows its name (falling back to title), an optional
+ * byte size, and its URL.
+ */
+export function formatAttachmentsLine(attachments: Attachment[] | undefined): string | undefined {
+    if (!attachments || attachments.length === 0) {
+        return undefined
+    }
+    const items = attachments
+        .map((a) => {
+            const name = a.fileName ?? a.title ?? undefined
+            const size = typeof a.fileSize === 'number' ? ` (${a.fileSize} bytes)` : ''
+            const url = a.url ?? undefined
+            if (name) {
+                return url ? `${name}${size}${URL_SEPARATOR}${url}` : `${name}${size}`
+            }
+            return url ?? '(unnamed attachment)'
+        })
+        .join('; ')
+    return `**Attachments (${attachments.length}):** ${items}`
+}

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -35,6 +35,20 @@ export {
 // Custom schemas for tool-specific structured outputs
 
 /**
+ * Schema for a Twist attachment as returned by the API.
+ *
+ * Typical fields include `attachmentId`, `fileName`, `fileSize`, `title`,
+ * `underlyingType` (mime type), `uploadState`, `url` (download URL), and
+ * `urlType`. The shape is kept permissive to forward-pass any fields the API
+ * adds without an MCP release.
+ *
+ * Note: the `url` points at `files.twist.com/...` and currently requires a
+ * browser session cookie to download — there is no OAuth-authenticated
+ * attachment download endpoint on the public Twist REST API today.
+ */
+const AttachmentSchema = z.record(z.string(), z.unknown())
+
+/**
  * Schema for load-thread tool output
  */
 export const LoadThreadOutputSchema = z.object({
@@ -55,6 +69,7 @@ export const LoadThreadOutputSchema = z.object({
         participants: z.array(z.number()).optional(),
         participantNames: z.array(z.string()).optional(),
         threadUrl: z.string(),
+        attachments: z.array(AttachmentSchema).optional(),
     }),
     comments: z.array(
         z.object({
@@ -65,6 +80,7 @@ export const LoadThreadOutputSchema = z.object({
             threadId: z.number(),
             posted: z.string(),
             commentUrl: z.string(),
+            attachments: z.array(AttachmentSchema).optional(),
         }),
     ),
     totalComments: z.number(),
@@ -93,6 +109,7 @@ export const LoadConversationOutputSchema = z.object({
             conversationId: z.number(),
             posted: z.string(),
             messageUrl: z.string(),
+            attachments: z.array(AttachmentSchema).optional(),
         }),
     ),
     totalMessages: z.number(),

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -1,4 +1,5 @@
 import {
+    type Attachment,
     ChannelSchema,
     CommentSchema,
     ConversationMessageSchema,
@@ -35,18 +36,39 @@ export {
 // Custom schemas for tool-specific structured outputs
 
 /**
- * Schema for a Twist attachment as returned by the API.
+ * Schema for a Twist attachment as returned by the API, mirroring the SDK's
+ * `AttachmentSchema` field-for-field.
  *
- * Typical fields include `attachmentId`, `fileName`, `fileSize`, `title`,
- * `underlyingType` (mime type), `uploadState`, `url` (download URL), and
- * `urlType`. The shape is kept permissive to forward-pass any fields the API
- * adds without an MCP release.
+ * The SDK ships its own bundled copy of zod, so composing the SDK's
+ * `AttachmentSchema` directly into the output schemas below trips TypeScript's
+ * portable-type-name check (TS2883). To keep the real field types in structured
+ * output we model the same shape here in the project's zod, and bind it to the
+ * SDK's `Attachment` type so the two can't silently drift. `looseObject`
+ * preserves the SDK's `$loose` behaviour: fields the API adds forward-pass
+ * untouched without an MCP release.
  *
- * Note: the `url` points at `files.twist.com/...` and currently requires a
- * browser session cookie to download — there is no OAuth-authenticated
+ * Note: an attachment's `url` points at `files.twist.com/...` and currently
+ * requires a browser session cookie to download — there is no OAuth-authenticated
  * attachment download endpoint on the public Twist REST API today.
  */
-const AttachmentSchema = z.record(z.string(), z.unknown())
+const AttachmentSchema = z.looseObject({
+    attachmentId: z.string(),
+    urlType: z.string(),
+    title: z.string().nullish(),
+    url: z.string().nullish(),
+    fileName: z.string().nullish(),
+    fileSize: z.number().nullish(),
+    underlyingType: z.string().nullish(),
+    description: z.string().nullish(),
+    image: z.string().nullish(),
+    imageWidth: z.number().nullish(),
+    imageHeight: z.number().nullish(),
+    duration: z.string().nullish(),
+    uploadState: z.string().nullish(),
+    video: z.string().nullish(),
+    videoType: z.string().nullish(),
+    videoAutoPlay: z.boolean().nullish(),
+}) satisfies z.ZodType<Attachment>
 
 /**
  * Schema for load-thread tool output


### PR DESCRIPTION
## Problem

The SDK returns full attachment metadata (URL, filename, size, mime type, upload state) on each comment, thread body, and message — but the MCP layer drops it when remapping into structured output. Agents calling `load-thread` or `load-conversation` can't see that a comment has an attachment, let alone its URL.

Concrete repro: a teammate posts an SSH pubkey as a file attachment. The MCP returns just the comment body (`"here's my public SSH key attached"`) with no signal that an attachment exists. The agent has to either ask the user to paste the contents, or fall back to a raw SDK call to recover the URL.

## Fix

Add an optional `attachments[]` field to the structured output for:

- `LoadThreadOutputSchema.thread` (thread-body attachments)
- `LoadThreadOutputSchema.comments[]` (per-comment attachments)
- `LoadConversationOutputSchema.messages[]` (DM message attachments)

Also render an `**Attachments (N):** name (size bytes) — url` line in the human-readable text output when attachments are present, so models that read the text branch instead of the structured branch still see them.

The schema shape is intentionally permissive — `z.record(z.string(), z.unknown())` — to match the SDK's `z.unknown()` typing on the underlying field, and to forward-pass any new fields the Twist API adds without needing an MCP release.

## Limitation (worth noting in case Doist wants to extend the API)

The `url` on each attachment points at `files.twist.com/...` and currently requires a **browser session cookie** to download. There's no OAuth-authenticated attachment download endpoint on the public Twist REST API today (`/api/v3/attachments/getone` returns 404; `Bearer $TOKEN` against `files.twist.com` redirects to login). So this PR only surfaces metadata + URL — it doesn't enable programmatic download. If an OAuth-authenticated download endpoint were added server-side, an MCP `download-attachment` tool would be a natural follow-up.

## Tests

- 3 new `load-thread` cases:
  - comment attachments flow through to structured + text output
  - thread-body attachments flow through
  - empty `attachments: []` arrays are correctly omitted (no extra field, no empty line)
- 1 new `load-conversation` case (message attachments flow through)
- All existing **193 tests + 47 snapshots** still pass unchanged (the existing mocks use `attachments: []`, which is correctly normalized to "no field")

## Verified

```
Test Suites: 18 passed, 18 total
Tests:       197 passed, 197 total
Snapshots:   47 passed, 47 total
```

Format check, type-check, and build all clean.