### PR TITLE
fix(release): send client_payload as a JSON object in the integrations dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,14 +136,19 @@ jobs:
 
             - name: Trigger twist-ai-integrations update
               if: ${{ steps.announcement.outputs.should_announce == 'true' }}
+              env:
+                  GH_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+                  VERSION: ${{ steps.announcement.outputs.package_version }}
               run: |
+                  # `client_payload` must be sent as nested fields so gh builds a
+                  # JSON object; passing a JSON string via a single `-f` is
+                  # rejected by the dispatches API with HTTP 422 ("not an object").
                   gh api \
                     --method POST \
                     -H "Accept: application/vnd.github+json" \
                     -H "X-GitHub-Api-Version: 2022-11-28" \
                     /repos/Doist/twist-ai-integrations/dispatches \
                     -f event_type='twist-ai-updated' \
-                    -f client_payload='{"version":"${{ steps.announcement.outputs.package_version }}","npm_tag":"latest"}'
-              env:
-                  GH_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+                    -f "client_payload[version]=${VERSION}" \
+                    -f "client_payload[npm_tag]=latest"
               continue-on-error: true


### PR DESCRIPTION
## Problem

The Release workflow's "Trigger twist-ai-integrations update" step never actually triggers the downstream update. Same bug as [Doist/todoist-mcp#512](https://github.com/Doist/todoist-mcp/pull/512):

```bash
-f client_payload='{"version":"...","npm_tag":"latest"}'
```

`gh api -f` sends every value as a **string**, but the `repository_dispatch` API requires `client_payload` to be a JSON **object**, so the call is rejected with **HTTP 422** (`"... is not an object"`) and the dispatch never fires. Because the step is `continue-on-error: true`, the release stays green and the failure is silently swallowed.

Not a token or event-type problem: `event_type=twist-ai-updated` is correctly registered in the receiver (`Doist/twist-ai-integrations` `update-twist-ai.yml`: `types: [twist-ai-updated]`).

## Fix

Build `client_payload` with gh's nested-field syntax so it's sent as an object, matching the working `comms-mcp` workflow:

```bash
-f "client_payload[version]=${VERSION}" \
-f "client_payload[npm_tag]=latest"
```

`continue-on-error: true` is intentionally **kept**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)